### PR TITLE
Corrected version of #126, with checkstyle amendments

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -1,6 +1,7 @@
 package seedu.address.logic;
 
 import java.nio.file.Path;
+import java.time.Clock;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
@@ -47,4 +48,14 @@ public interface Logic {
      * Set the user prefs' GUI settings.
      */
     void setGuiSettings(GuiSettings guiSettings);
+
+    /**
+     * Set the clock the app is to run on
+     */
+    void setClock(Clock clock);
+
+    /**
+     * Get the clock the app is running on
+     */
+    Clock getClock();
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -3,6 +3,7 @@ package seedu.address.logic;
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.Path;
+import java.time.Clock;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
@@ -33,6 +34,8 @@ public class LogicManager implements Logic {
     private final Storage storage;
     private final AddressBookParser addressBookParser;
 
+
+
     /**
      * Constructs a {@code LogicManager} with the given {@code Model} and {@code Storage}.
      */
@@ -47,7 +50,7 @@ public class LogicManager implements Logic {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
 
         CommandResult commandResult;
-        Command command = addressBookParser.parseCommand(commandText);
+        Command command = addressBookParser.withClock(this.getClock()).parseCommand(commandText);
         commandResult = command.execute(model);
 
         try {
@@ -84,5 +87,14 @@ public class LogicManager implements Logic {
     @Override
     public void setGuiSettings(GuiSettings guiSettings) {
         model.setGuiSettings(guiSettings);
+    }
+
+    @Override
+    public void setClock(Clock clock) {
+        model.setClock(clock);
+    }
+    @Override
+    public Clock getClock() {
+        return model.getClock();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -268,7 +268,6 @@ public class EditCommand extends Command {
                     && Objects.equals(email, otherEditPersonDescriptor.email)
                     && Objects.equals(company, otherEditPersonDescriptor.company)
                     && Objects.equals(job, otherEditPersonDescriptor.job)
-                    && Objects.equals(tags, otherEditPersonDescriptor.tags);
                     && Objects.equals(tags, otherEditPersonDescriptor.tags)
                     && Objects.equals(lastModifiedDateTime, otherEditPersonDescriptor.lastModifiedDateTime);
         }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -25,6 +25,7 @@ import seedu.address.model.Model;
 import seedu.address.model.person.Company;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Job;
+import seedu.address.model.person.LastModifiedDateTime;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -104,8 +105,16 @@ public class EditCommand extends Command {
         Company updatedCompany = editPersonDescriptor.getCompany().orElse(personToEdit.getCompany());
         Job updatedJob = editPersonDescriptor.getJob().orElse(personToEdit.getJob());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
-
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedCompany, updatedJob, updatedTags);
+        LastModifiedDateTime updatedLastModifiedDateTime =
+                editPersonDescriptor.getLastModifiedDateTime()
+                        .orElse(personToEdit.getLastModifiedDateTime());
+        // While semantically, it would make sense that this would always be changed,
+        // We do it like this for consistency with other fields
+        // And to move responsibility for updating this field to the parser,
+        // Like the other fields.
+        return new Person(updatedName, updatedPhone,
+                updatedEmail, updatedCompany, updatedJob,
+                updatedTags, updatedLastModifiedDateTime);
     }
 
     @Override
@@ -144,6 +153,8 @@ public class EditCommand extends Command {
         private Job job;
         private Set<Tag> tags;
 
+        private LastModifiedDateTime lastModifiedDateTime;
+
         public EditPersonDescriptor() {}
 
         /**
@@ -157,6 +168,7 @@ public class EditCommand extends Command {
             setCompany(toCopy.company);
             setJob(toCopy.job);
             setTags(toCopy.tags);
+            setLastModifiedDateTime(toCopy.lastModifiedDateTime);
         }
 
         /**
@@ -223,6 +235,22 @@ public class EditCommand extends Command {
             return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
         }
 
+        /**
+         * Setter for the last modified date & time as a @code LastModifiedDateTime object
+         */
+
+        public void setLastModifiedDateTime(LastModifiedDateTime lastModifiedDateTime) {
+            this.lastModifiedDateTime = lastModifiedDateTime;
+        }
+
+        /**
+         * Getter for last modified date & time as a @code LastModifiedDateTime object,
+         * wrapped in an instance of @code Optional.
+         */
+        public Optional<LastModifiedDateTime> getLastModifiedDateTime() {
+            return Optional.ofNullable(lastModifiedDateTime);
+        }
+
         @Override
         public boolean equals(Object other) {
             if (other == this) {
@@ -241,6 +269,8 @@ public class EditCommand extends Command {
                     && Objects.equals(company, otherEditPersonDescriptor.company)
                     && Objects.equals(job, otherEditPersonDescriptor.job)
                     && Objects.equals(tags, otherEditPersonDescriptor.tags);
+                    && Objects.equals(tags, otherEditPersonDescriptor.tags)
+                    && Objects.equals(lastModifiedDateTime, otherEditPersonDescriptor.lastModifiedDateTime);
         }
 
         @Override
@@ -252,6 +282,7 @@ public class EditCommand extends Command {
                     .add("company", company)
                     .add("job", job)
                     .add("tags", tags)
+                    .add("last_modified", lastModifiedDateTime)
                     .toString();
         }
     }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -26,7 +27,9 @@ import seedu.address.model.tag.Tag;
 /**
  * Parses input arguments and creates a new AddCommand object
  */
-public class AddCommandParser implements Parser<AddCommand> {
+public class AddCommandParser implements ClockDependantParser<AddCommand> {
+
+    private Clock clock = Clock.systemDefaultZone();
 
     /**
      * Parses the given {@code String} of arguments in the context of the AddCommand
@@ -50,11 +53,13 @@ public class AddCommandParser implements Parser<AddCommand> {
         Company company = ParserUtil.parseCompany(argMultimap.getValue(PREFIX_COMPANY).get());
         Job job = ParserUtil.parseJob(argMultimap.getValue(PREFIX_JOB).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
-
-        Person person = new Person(name, phone, email, company, job, tagList);
+        LastModifiedDateTime lastModifiedDateTime = new LastModifiedDateTime(LocalDateTime.now(clock));
+        Person person = new Person(name, phone, email, company, job, tagList,lastModifiedDateTime);
 
         return new AddCommand(person);
     }
+
+
 
     /**
      * Returns true if none of the prefixes contains empty {@code Optional} values in the given
@@ -64,4 +69,15 @@ public class AddCommandParser implements Parser<AddCommand> {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
+    /**
+     * To specify usage of a specific clock.
+     * @param clock The clock to use
+     * @return an edited parser using the specified clock
+     */
+    @Override
+    public AddCommandParser withClock(Clock clock) {
+       AddCommandParser toReturn = new AddCommandParser();
+       toReturn.clock = clock;
+       return toReturn;
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -54,7 +54,7 @@ public class AddCommandParser implements ClockDependantParser<AddCommand> {
         Job job = ParserUtil.parseJob(argMultimap.getValue(PREFIX_JOB).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
         LastModifiedDateTime lastModifiedDateTime = new LastModifiedDateTime(LocalDateTime.now(clock));
-        Person person = new Person(name, phone, email, company, job, tagList,lastModifiedDateTime);
+        Person person = new Person(name, phone, email, company, job, tagList, lastModifiedDateTime);
 
         return new AddCommand(person);
     }
@@ -76,8 +76,8 @@ public class AddCommandParser implements ClockDependantParser<AddCommand> {
      */
     @Override
     public AddCommandParser withClock(Clock clock) {
-       AddCommandParser toReturn = new AddCommandParser();
-       toReturn.clock = clock;
-       return toReturn;
+        AddCommandParser toReturn = new AddCommandParser();
+        toReturn.clock = clock;
+        return toReturn;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.time.LocalDateTime;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -16,6 +17,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Company;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Job;
+import seedu.address.model.person.LastModifiedDateTime;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -24,7 +24,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 /**
  * Parses user input.
  */
-public class AddressBookParser implements ClockDependantParser<Command>{
+public class AddressBookParser implements ClockDependantParser<Command> {
 
     /**
      * Used for initial separation of command word and args.

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 
+import java.time.Clock;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -23,13 +24,15 @@ import seedu.address.logic.parser.exceptions.ParseException;
 /**
  * Parses user input.
  */
-public class AddressBookParser {
+public class AddressBookParser implements ClockDependantParser<Command>{
 
     /**
      * Used for initial separation of command word and args.
      */
     private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
     private static final Logger logger = LogsCenter.getLogger(AddressBookParser.class);
+
+    private Clock clock = Clock.systemDefaultZone();
 
     /**
      * Parses user input into command for execution.
@@ -55,10 +58,10 @@ public class AddressBookParser {
         switch (commandWord) {
 
         case AddCommand.COMMAND_WORD:
-            return new AddCommandParser().parse(arguments);
+            return new AddCommandParser().withClock(clock).parse(arguments);
 
         case EditCommand.COMMAND_WORD:
-            return new EditCommandParser().parse(arguments);
+            return new EditCommandParser().withClock(clock).parse(arguments);
 
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);
@@ -87,4 +90,29 @@ public class AddressBookParser {
         }
     }
 
+    /**
+     * To specify usage of a specific clock.
+     *
+     * @param clock The clock to use
+     * @return an edited parser using the specified clock
+     */
+    @Override
+    public AddressBookParser withClock(Clock clock) {
+        AddressBookParser toReturn = new AddressBookParser();
+        toReturn.clock = clock;
+        return toReturn;
+    }
+
+
+    /**
+     * Parses {@code userInput} into a command and returns it. Same as parseCommand.
+     *
+     * @param userInput
+     * @throws ParseException if {@code userInput} does not conform the expected format
+     */
+    @Override
+    public Command parse(String userInput) throws ParseException {
+        // Suggest : Refactor parseCommand to parse.
+        return parseCommand(userInput);
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/ClockDependantParser.java
+++ b/src/main/java/seedu/address/logic/parser/ClockDependantParser.java
@@ -1,0 +1,19 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.Command;
+
+import java.time.Clock;
+
+/**
+ * Parsers that are somehow dependent on a specific clock for date & time.
+ * @param <T> the type of command
+ */
+public interface ClockDependantParser<T extends Command> extends Parser<T> {
+
+    /**
+     * To specify usage of a specific clock.
+     * @param clock The clock to use
+     * @return an edited parser using the specified clock
+     */
+    public ClockDependantParser<T> withClock(Clock clock);
+}

--- a/src/main/java/seedu/address/logic/parser/ClockDependantParser.java
+++ b/src/main/java/seedu/address/logic/parser/ClockDependantParser.java
@@ -1,9 +1,8 @@
 package seedu.address.logic.parser;
 
-import seedu.address.logic.commands.Command;
-
 import java.time.Clock;
 
+import seedu.address.logic.commands.Command;
 /**
  * Parsers that are somehow dependent on a specific clock for date & time.
  * @param <T> the type of command

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -17,7 +17,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -9,6 +9,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
@@ -18,6 +19,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.LastModifiedDateTime;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -64,6 +66,9 @@ public class EditCommandParser implements Parser<EditCommand> {
             editPersonDescriptor.setJob(ParserUtil.parseJob(argMultimap.getValue(PREFIX_JOB).get()));
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
+
+        // always set this, as this is set by the system and NOT the user
+        editPersonDescriptor.setLastModifiedDateTime(new LastModifiedDateTime(LocalDateTime.now()));
 
         if (!editPersonDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -9,6 +9,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Collections;
@@ -16,6 +17,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -25,7 +27,9 @@ import seedu.address.model.tag.Tag;
 /**
  * Parses input arguments and creates a new EditCommand object
  */
-public class EditCommandParser implements Parser<EditCommand> {
+public class EditCommandParser implements ClockDependantParser<EditCommand> {
+
+    private Clock clock = Clock.systemDefaultZone();
 
     /**
      * Parses the given {@code String} of arguments in the context of the EditCommand
@@ -68,7 +72,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
 
         // always set this, as this is set by the system and NOT the user
-        editPersonDescriptor.setLastModifiedDateTime(new LastModifiedDateTime(LocalDateTime.now()));
+        editPersonDescriptor.setLastModifiedDateTime(new LastModifiedDateTime(LocalDateTime.now(clock)));
 
         if (!editPersonDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
@@ -92,4 +96,16 @@ public class EditCommandParser implements Parser<EditCommand> {
         return Optional.of(ParserUtil.parseTags(tagSet));
     }
 
+    /**
+     * To specify usage of a specific clock.
+     *
+     * @param clock The clock to use
+     * @return an edited parser using the specified clock
+     */
+    @Override
+    public EditCommandParser withClock(Clock clock) {
+        EditCommandParser toReturn = new EditCommandParser();
+        toReturn.clock = clock;
+        return toReturn;
+    }
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.time.Clock;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -33,6 +34,16 @@ public interface Model {
      * Sets the user prefs' GUI settings.
      */
     void setGuiSettings(GuiSettings guiSettings);
+
+    /**
+     * Set the clock the Model is running on
+     */
+    void setClock(Clock clock);
+
+    /**
+     * Get the clock the Model is running on
+     */
+    Clock getClock();
 
     /**
      * Returns the user prefs' address book file path.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.time.Clock;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -23,21 +24,26 @@ public class ModelManager implements Model {
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
 
+    private Clock clock;
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
      */
     public ModelManager(ReadOnlyAddressBook addressBook, ReadOnlyUserPrefs userPrefs) {
-        requireAllNonNull(addressBook, userPrefs);
+        this(addressBook, userPrefs, Clock.systemDefaultZone());
+    }
 
+    public ModelManager() {
+        this(new AddressBook(), new UserPrefs());
+    }
+    public ModelManager(ReadOnlyAddressBook addressBook, ReadOnlyUserPrefs userPrefs, Clock clock) {
+        requireAllNonNull(addressBook,userPrefs,clock);
         logger.fine("Initializing with address book: " + addressBook + " and user prefs " + userPrefs);
 
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
-    }
+        this.clock = Clock.systemDefaultZone();
 
-    public ModelManager() {
-        this(new AddressBook(), new UserPrefs());
     }
 
     //=========== UserPrefs ==================================================================================
@@ -62,6 +68,17 @@ public class ModelManager implements Model {
     public void setGuiSettings(GuiSettings guiSettings) {
         requireNonNull(guiSettings);
         userPrefs.setGuiSettings(guiSettings);
+    }
+
+
+    @Override
+    public void setClock(Clock clock) {
+        this.clock = clock;
+    }
+
+    @Override
+    public Clock getClock() {
+        return this.clock;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -26,7 +26,7 @@ public class ModelManager implements Model {
 
     private Clock clock;
     /**
-     * Initializes a ModelManager with the given addressBook and userPrefs.
+     * Initializes a ModelManager with the given addressBook and userPrefs, using the system default clock.
      */
     public ModelManager(ReadOnlyAddressBook addressBook, ReadOnlyUserPrefs userPrefs) {
         this(addressBook, userPrefs, Clock.systemDefaultZone());
@@ -35,8 +35,12 @@ public class ModelManager implements Model {
     public ModelManager() {
         this(new AddressBook(), new UserPrefs());
     }
+
+    /**
+     * Initialises a ModelManager with the given addressBook, userPrefs & Clock
+     */
     public ModelManager(ReadOnlyAddressBook addressBook, ReadOnlyUserPrefs userPrefs, Clock clock) {
-        requireAllNonNull(addressBook,userPrefs,clock);
+        requireAllNonNull(addressBook, userPrefs, clock);
         logger.fine("Initializing with address book: " + addressBook + " and user prefs " + userPrefs);
 
         this.addressBook = new AddressBook(addressBook);

--- a/src/main/java/seedu/address/model/ReadOnlyUserPrefs.java
+++ b/src/main/java/seedu/address/model/ReadOnlyUserPrefs.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.time.Clock;
 
 import seedu.address.commons.core.GuiSettings;
 
@@ -12,5 +13,6 @@ public interface ReadOnlyUserPrefs {
     GuiSettings getGuiSettings();
 
     Path getAddressBookFilePath();
+
 
 }

--- a/src/main/java/seedu/address/model/ReadOnlyUserPrefs.java
+++ b/src/main/java/seedu/address/model/ReadOnlyUserPrefs.java
@@ -1,7 +1,6 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
-import java.time.Clock;
 
 import seedu.address.commons.core.GuiSettings;
 

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -4,17 +4,19 @@ import static java.util.Objects.requireNonNull;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Clock;
 import java.util.Objects;
 
 import seedu.address.commons.core.GuiSettings;
 
 /**
- * Represents User's preferences.
+ * Represents User's preferences & settings.
  */
 public class UserPrefs implements ReadOnlyUserPrefs {
 
     private GuiSettings guiSettings = new GuiSettings();
     private Path addressBookFilePath = Paths.get("data" , "addressbook.json");
+
 
     /**
      * Creates a {@code UserPrefs} with default values.
@@ -50,6 +52,7 @@ public class UserPrefs implements ReadOnlyUserPrefs {
     public Path getAddressBookFilePath() {
         return addressBookFilePath;
     }
+
 
     public void setAddressBookFilePath(Path addressBookFilePath) {
         requireNonNull(addressBookFilePath);

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.Clock;
 import java.util.Objects;
 
 import seedu.address.commons.core.GuiSettings;

--- a/src/main/java/seedu/address/model/person/LastModifiedDateTime.java
+++ b/src/main/java/seedu/address/model/person/LastModifiedDateTime.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.format.FormatStyle;
+import java.time.temporal.ChronoUnit;
 import java.util.Locale;
 
 
@@ -47,7 +48,7 @@ public class LastModifiedDateTime {
      */
     public LastModifiedDateTime(LocalDateTime lastModified) {
         requireNonNull(lastModified);
-        this.lastModified = lastModified;
+        this.lastModified = lastModified.truncatedTo(ChronoUnit.SECONDS);
         // no other sanity checking should be required, as the
         // LocalDateTime object encapsulates already.
         // No sanity checking on the SEMANTICS of the provided LocalDateTime is provided.

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -27,22 +27,9 @@ public class Person {
     private final Set<Tag> tags = new HashSet<>();
 
     private final LastModifiedDateTime lastModifiedDateTime;
-    /**
-     * Every field must be present and not null
-     */
-    public Person(Name name, Phone phone, Email email, Company company, Job job, Set<Tag> tags) {
-        requireAllNonNull(name, phone, email, company, job, tags);
-        this.name = name;
-        this.phone = phone;
-        this.email = email;
-        this.company = company;
-        this.job = job;
-        this.tags.addAll(tags);
-        this.lastModifiedDateTime = new LastModifiedDateTime(LastModifiedDateTime.DEFAULT_LAST_MODIFIED);
-    }
 
     /**
-     * Constructor that allows setting of lastModifiedDateTime field.
+     * Every field must be present and not null
      */
     public Person(Name name, Phone phone, Email email, Company company, Job job, Set<Tag> tags,
                   LastModifiedDateTime lastModifiedDateTime) {

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -9,6 +9,7 @@ import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Company;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Job;
+import seedu.address.model.person.LastModifiedDateTime;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -23,27 +24,33 @@ public class SampleDataUtil {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new Company("Google"),
                 new Job("Data Analyst"),
-                getTagSet("friends")),
+                getTagSet("friends"),
+                    new LastModifiedDateTime(LastModifiedDateTime.DEFAULT_LAST_MODIFIED)),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                     new Company("ShopBack"),
                     new Job("Software Engineer"),
-                getTagSet("colleagues", "friends")),
+                getTagSet("colleagues", "friends"),
+                    new LastModifiedDateTime(LastModifiedDateTime.DEFAULT_LAST_MODIFIED)),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                     new Company("Microsoft"),
                     new Job("Data Engineer"),
-                getTagSet("neighbours")),
+                getTagSet("neighbours"),
+                    new LastModifiedDateTime(LastModifiedDateTime.DEFAULT_LAST_MODIFIED)),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                     new Company("Optiver"),
                     new Job("Quantitative trader"),
-                getTagSet("family")),
+                getTagSet("family"),
+                    new LastModifiedDateTime(LastModifiedDateTime.DEFAULT_LAST_MODIFIED)),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                     new Company("Proctor & Gamble"),
                     new Job("UI/UX designer"),
-                getTagSet("classmates")),
+                getTagSet("classmates"),
+                    new LastModifiedDateTime(LastModifiedDateTime.DEFAULT_LAST_MODIFIED)),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                     new Company("Food Panda"),
                     new Job("Data Analyst"),
-                getTagSet("colleagues"))
+                getTagSet("colleagues"),
+                    new LastModifiedDateTime(LastModifiedDateTime.DEFAULT_LAST_MODIFIED))
         };
     }
 

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -7,7 +7,7 @@
     "company": "Google",
     "job": "AI Analyst",
     "tags" : [ "friends" ],
-    "last_modified" : "10 Oct 2000, 10:10:00"
+    "last_modified" : "10 Oct 2000, 10:10:10"
   }, {
     "name" : "Benson Meier",
     "phone" : "98765432",
@@ -15,7 +15,7 @@
     "company": "Mandai Wildlife Group",
     "job": "Software Engineer",
     "tags" : [ "owesMoney", "friends" ],
-    "last_modified" : "10 Oct 2000, 10:10:00"
+    "last_modified" : "10 Oct 2000, 10:10:10"
   }, {
     "name" : "Carl Kurz",
     "phone" : "95352563",
@@ -23,7 +23,7 @@
     "company": "Grab",
     "job": "AI Engineer",
     "tags" : [ ],
-    "last_modified" : "10 Oct 2000, 10:10:00"
+    "last_modified" : "10 Oct 2000, 10:10:10"
   }, {
     "name" : "Daniel Meier",
     "phone" : "87652533",
@@ -31,7 +31,7 @@
     "company": "Uber",
     "job": "Data Analyst",
     "tags" : [ "friends" ],
-    "last_modified" : "10 Oct 2000, 10:10:00"
+    "last_modified" : "10 Oct 2000, 10:10:10"
   }, {
     "name" : "Elle Meyer",
     "phone" : "9482224",
@@ -39,7 +39,7 @@
     "company": "Central Provident Board",
     "job": "Machine Learning Analyst",
     "tags" : [ ],
-    "last_modified" : "10 Oct 2000, 10:10:00"
+    "last_modified" : "10 Oct 2000, 10:10:10"
   }, {
     "name" : "Fiona Kunz",
     "phone" : "9482427",
@@ -47,7 +47,7 @@
     "company": "Citadel",
     "job": "AI Engineer",
     "tags" : [ ],
-    "last_modified" : "10 Oct 2000, 10:10:00"
+    "last_modified" : "10 Oct 2000, 10:10:10"
   }, {
     "name" : "George Best",
     "phone" : "9482442",
@@ -55,6 +55,6 @@
     "company": "Morgan Stanley",
     "job": "Risk Analyst",
     "tags" : [ ],
-    "last_modified" : "10 Oct 2000, 10:10:00"
+    "last_modified" : "10 Oct 2000, 10:10:10"
   } ]
 }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -1,7 +1,6 @@
 package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.COMPANY_DESC_AMY;
@@ -12,14 +11,12 @@ import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.ClockUtil.DEFAULT_TEST_CLOCK;
 import static seedu.address.testutil.ClockUtil.DEFAULT_TEST_TIME;
-import static seedu.address.testutil.ClockUtil.OTHER_TEST_CLOCK;
 import static seedu.address.testutil.TypicalPersons.AMY;
 
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.Path;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.COMPANY_DESC_AMY;
@@ -11,12 +12,14 @@ import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.ClockUtil.DEFAULT_TEST_CLOCK;
 import static seedu.address.testutil.ClockUtil.DEFAULT_TEST_TIME;
+import static seedu.address.testutil.ClockUtil.OTHER_TEST_CLOCK;
 import static seedu.address.testutil.TypicalPersons.AMY;
 
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.Path;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -96,6 +99,7 @@ public class LogicManagerTest {
     public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> logic.getFilteredPersonList().remove(0));
     }
+
 
     /**
      * Executes the command and confirms that

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -9,6 +9,8 @@ import static seedu.address.logic.commands.CommandTestUtil.JOB_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.ClockUtil.DEFAULT_TEST_CLOCK;
+import static seedu.address.testutil.ClockUtil.DEFAULT_TEST_TIME;
 import static seedu.address.testutil.TypicalPersons.AMY;
 
 import java.io.IOException;
@@ -42,7 +44,12 @@ public class LogicManagerTest {
     public Path temporaryFolder;
 
     private Model model = new ModelManager();
+    {
+        model.setClock(DEFAULT_TEST_CLOCK);
+    }
+
     private Logic logic;
+
 
     @BeforeEach
     public void setUp() {
@@ -50,7 +57,9 @@ public class LogicManagerTest {
                 new JsonAddressBookStorage(temporaryFolder.resolve("addressBook.json"));
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.resolve("userPrefs.json"));
         StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
+
         logic = new LogicManager(model, storage);
+        logic.setClock(DEFAULT_TEST_CLOCK);
     }
 
     @Test
@@ -164,12 +173,14 @@ public class LogicManagerTest {
         StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
 
         logic = new LogicManager(model, storage);
-
+        logic.setClock(DEFAULT_TEST_CLOCK);
         // Triggers the saveAddressBook method by executing an add command
         String addCommand = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY
                 + EMAIL_DESC_AMY + COMPANY_DESC_AMY + JOB_DESC_AMY;
-        Person expectedPerson = new PersonBuilder(AMY).withTags().build();
+        Person expectedPerson = new PersonBuilder(AMY)
+                .withTags().withLastModifiedDateTime(DEFAULT_TEST_TIME).build();
         ModelManager expectedModel = new ModelManager();
+        expectedModel.setClock(DEFAULT_TEST_CLOCK);
         expectedModel.addPerson(expectedPerson);
         assertCommandFailure(addCommand, CommandException.class, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -8,6 +8,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 
 import java.nio.file.Path;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.function.Predicate;
@@ -105,6 +106,16 @@ public class AddCommandTest {
 
         @Override
         public void setGuiSettings(GuiSettings guiSettings) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setClock(Clock clock) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Clock getClock() {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.ClockUtil.DEFAULT_TEST_TIME;
+import static seedu.address.testutil.ClockUtil.OTHER_TEST_TIME;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 
 import java.nio.file.Path;
@@ -56,10 +58,12 @@ public class AddCommandTest {
 
     @Test
     public void equals() {
-        Person alice = new PersonBuilder().withName("Alice").build();
+        Person alice = new PersonBuilder().withName("Alice").withLastModifiedDateTime(DEFAULT_TEST_TIME).build();
         Person bob = new PersonBuilder().withName("Bob").build();
+        Person aliceDiffTime = new PersonBuilder().withName("Alice").withLastModifiedDateTime(OTHER_TEST_TIME).build();
         AddCommand addAliceCommand = new AddCommand(alice);
         AddCommand addBobCommand = new AddCommand(bob);
+        AddCommand addDiffTimeCommand = new AddCommand(aliceDiffTime);
 
         // same object -> returns true
         assertTrue(addAliceCommand.equals(addAliceCommand));
@@ -76,6 +80,9 @@ public class AddCommandTest {
 
         // different person -> returns false
         assertFalse(addAliceCommand.equals(addBobCommand));
+
+        //different time -> returns false
+        assertFalse(addAliceCommand.equals(addDiffTimeCommand));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -79,7 +79,8 @@ public class CommandTestUtil {
         DESC_BOB = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withCompany(VALID_COMPANY_BOB)
                 .withJob(VALID_JOB_BOB)
-                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).withLastModifiedDateTime(VALID_LAST_MODIFIED_BOB).build();
+                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
+                .withLastModifiedDateTime(VALID_LAST_MODIFIED_BOB).build();
         DESC_AMYDIFFTIME = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withCompany(VALID_COMPANY_AMY)
                 .withJob(VALID_JOB_AMY)

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -69,16 +69,21 @@ public class CommandTestUtil {
 
     public static final EditCommand.EditPersonDescriptor DESC_AMY;
     public static final EditCommand.EditPersonDescriptor DESC_BOB;
+    public static final EditCommand.EditPersonDescriptor DESC_AMYDIFFTIME;
 
     static {
         DESC_AMY = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withCompany(VALID_COMPANY_AMY)
                 .withJob(VALID_JOB_AMY)
-                .withTags(VALID_TAG_FRIEND).build();
+                .withTags(VALID_TAG_FRIEND).withLastModifiedDateTime(VALID_LAST_MODIFIED_AMY).build();
         DESC_BOB = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withCompany(VALID_COMPANY_BOB)
                 .withJob(VALID_JOB_BOB)
-                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).withLastModifiedDateTime(VALID_LAST_MODIFIED_BOB).build();
+        DESC_AMYDIFFTIME = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
+                .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withCompany(VALID_COMPANY_AMY)
+                .withJob(VALID_JOB_AMY)
+                .withTags(VALID_TAG_FRIEND).withLastModifiedDateTime(VALID_LAST_MODIFIED_BOB).build();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -12,10 +12,8 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static seedu.address.testutil.ClockUtil.OTHER_TEST_TIME;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
-import static seedu.address.testutil.TypicalPersons.AMY;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
@@ -27,7 +25,6 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.person.LastModifiedDateTime;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_AMYDIFFTIME;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
@@ -11,8 +12,10 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.ClockUtil.OTHER_TEST_TIME;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.AMY;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
@@ -24,6 +27,7 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.LastModifiedDateTime;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
@@ -146,6 +150,7 @@ public class EditCommandTest {
         assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
+
     @Test
     public void equals() {
         final EditCommand standardCommand = new EditCommand(INDEX_FIRST_PERSON, DESC_AMY);
@@ -169,6 +174,9 @@ public class EditCommandTest {
 
         // different descriptor -> returns false
         assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_PERSON, DESC_BOB)));
+
+        //different time -> returns false
+        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_PERSON, DESC_AMYDIFFTIME)));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COMPANY_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_JOB_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LAST_MODIFIED_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
@@ -60,6 +61,10 @@ public class EditPersonDescriptorTest {
         // different tags -> returns false
         editedAmy = new EditPersonDescriptorBuilder(DESC_AMY).withTags(VALID_TAG_HUSBAND).build();
         assertFalse(DESC_AMY.equals(editedAmy));
+
+        // different time -> returns false
+        editedAmy = new EditPersonDescriptorBuilder(DESC_AMY).withLastModifiedDateTime(VALID_LAST_MODIFIED_BOB).build();
+        assertFalse(DESC_AMY.equals(editedAmy));
     }
 
     @Test
@@ -71,7 +76,8 @@ public class EditPersonDescriptorTest {
                 + editPersonDescriptor.getEmail().orElse(null) + ", company="
                 + editPersonDescriptor.getCompany().orElse(null) + ", job="
                 + editPersonDescriptor.getJob().orElse(null) + ", tags="
-                + editPersonDescriptor.getTags().orElse(null) + "}";
+                + editPersonDescriptor.getTags().orElse(null) + ", last_modified="
+                + editPersonDescriptor.getLastModifiedDateTime().orElse(null) + "}";
         assertEquals(expected, editPersonDescriptor.toString());
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -35,6 +35,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.ClockUtil.DEFAULT_TEST_CLOCK;
+import static seedu.address.testutil.ClockUtil.DEFAULT_TEST_TIME;
 import static seedu.address.testutil.TypicalPersons.AMY;
 import static seedu.address.testutil.TypicalPersons.BOB;
 
@@ -52,11 +54,12 @@ import seedu.address.model.tag.Tag;
 import seedu.address.testutil.PersonBuilder;
 
 public class AddCommandParserTest {
-    private AddCommandParser parser = new AddCommandParser();
+    private AddCommandParser parser = new AddCommandParser().withClock(DEFAULT_TEST_CLOCK);
 
     @Test
     public void parse_allFieldsPresent_success() {
-        Person expectedPerson = new PersonBuilder(BOB).withTags(VALID_TAG_FRIEND).build();
+        Person expectedPerson = new PersonBuilder(BOB).withTags(VALID_TAG_FRIEND)
+                .withLastModifiedDateTime(DEFAULT_TEST_TIME).build();
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
@@ -65,6 +68,7 @@ public class AddCommandParserTest {
 
         // multiple tags - all accepted
         Person expectedPersonMultipleTags = new PersonBuilder(BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
+                .withLastModifiedDateTime(DEFAULT_TEST_TIME)
                 .build();
         assertParseSuccess(parser,
                 NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + COMPANY_DESC_BOB
@@ -148,7 +152,7 @@ public class AddCommandParserTest {
     @Test
     public void parse_optionalFieldsMissing_success() {
         // zero tags
-        Person expectedPerson = new PersonBuilder(AMY).withTags().build();
+        Person expectedPerson = new PersonBuilder(AMY).withTags().withLastModifiedDateTime(DEFAULT_TEST_TIME).build();
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
                         + COMPANY_DESC_AMY + JOB_DESC_AMY,
                         new AddCommand(expectedPerson));

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.ClockUtil.DEFAULT_TEST_CLOCK;
+import static seedu.address.testutil.ClockUtil.DEFAULT_TEST_TIME;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import java.util.Arrays;
@@ -37,11 +39,11 @@ import seedu.address.testutil.PersonUtil;
 
 public class AddressBookParserTest {
 
-    private final AddressBookParser parser = new AddressBookParser();
+    private final AddressBookParser parser = new AddressBookParser().withClock(DEFAULT_TEST_CLOCK);
 
     @Test
     public void parseCommand_add() throws Exception {
-        Person person = new PersonBuilder().build();
+        Person person = new PersonBuilder().withLastModifiedDateTime(DEFAULT_TEST_TIME).build();
         AddCommand command = (AddCommand) parser.parseCommand(PersonUtil.getAddCommand(person));
         assertEquals(new AddCommand(person), command);
     }
@@ -61,7 +63,7 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_edit() throws Exception {
-        Person person = new PersonBuilder().build();
+        Person person = new PersonBuilder().withLastModifiedDateTime(DEFAULT_TEST_TIME).build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
                 + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));

--- a/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
+++ b/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -18,7 +19,8 @@ public class CommandParserTestUtil {
             Command expectedCommand) {
         try {
             Command command = parser.parse(userInput);
-            assertEquals(expectedCommand, command);
+            assertEquals(expectedCommand,command);
+
         } catch (ParseException pe) {
             throw new IllegalArgumentException("Invalid userInput.", pe);
         }

--- a/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
+++ b/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -19,7 +18,7 @@ public class CommandParserTestUtil {
             Command expectedCommand) {
         try {
             Command command = parser.parse(userInput);
-            assertEquals(expectedCommand,command);
+            assertEquals(expectedCommand, command);
 
         } catch (ParseException pe) {
             throw new IllegalArgumentException("Invalid userInput.", pe);

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -32,6 +32,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.ClockUtil.DEFAULT_TEST_CLOCK;
+import static seedu.address.testutil.ClockUtil.DEFAULT_TEST_TIME;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
@@ -50,6 +52,8 @@ import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 
+import java.time.LocalDateTime;
+
 public class EditCommandParserTest {
 
     private static final String TAG_EMPTY = " " + PREFIX_TAG;
@@ -57,7 +61,7 @@ public class EditCommandParserTest {
     private static final String MESSAGE_INVALID_FORMAT =
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);
 
-    private EditCommandParser parser = new EditCommandParser();
+    private EditCommandParser parser = new EditCommandParser().withClock(DEFAULT_TEST_CLOCK);
 
     @Test
     public void parse_missingParts_failure() {
@@ -119,7 +123,7 @@ public class EditCommandParserTest {
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY)
                 .withCompany(VALID_COMPANY_AMY).withJob(VALID_JOB_AMY)
-                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).withLastModifiedDateTime(DEFAULT_TEST_TIME).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -131,7 +135,7 @@ public class EditCommandParserTest {
         String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + EMAIL_DESC_AMY;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_BOB)
-                .withEmail(VALID_EMAIL_AMY).build();
+                .withEmail(VALID_EMAIL_AMY).withLastModifiedDateTime(DEFAULT_TEST_TIME).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -142,37 +146,43 @@ public class EditCommandParserTest {
         // name
         Index targetIndex = INDEX_THIRD_PERSON;
         String userInput = targetIndex.getOneBased() + NAME_DESC_AMY;
-        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY).build();
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
+                .withLastModifiedDateTime(DEFAULT_TEST_TIME).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // phone
         userInput = targetIndex.getOneBased() + PHONE_DESC_AMY;
-        descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_AMY).build();
+        descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_AMY)
+                .withLastModifiedDateTime(DEFAULT_TEST_TIME).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // email
         userInput = targetIndex.getOneBased() + EMAIL_DESC_AMY;
-        descriptor = new EditPersonDescriptorBuilder().withEmail(VALID_EMAIL_AMY).build();
+        descriptor = new EditPersonDescriptorBuilder().withEmail(VALID_EMAIL_AMY)
+                .withLastModifiedDateTime(DEFAULT_TEST_TIME).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // company
         userInput = targetIndex.getOneBased() + COMPANY_DESC_AMY;
-        descriptor = new EditPersonDescriptorBuilder().withCompany(VALID_COMPANY_AMY).build();
+        descriptor = new EditPersonDescriptorBuilder().withCompany(VALID_COMPANY_AMY)
+                .withLastModifiedDateTime(DEFAULT_TEST_TIME).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // job
         userInput = targetIndex.getOneBased() + JOB_DESC_AMY;
-        descriptor = new EditPersonDescriptorBuilder().withJob(VALID_JOB_AMY).build();
+        descriptor = new EditPersonDescriptorBuilder().withJob(VALID_JOB_AMY)
+                .withLastModifiedDateTime(DEFAULT_TEST_TIME).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // tags
         userInput = targetIndex.getOneBased() + TAG_DESC_FRIEND;
-        descriptor = new EditPersonDescriptorBuilder().withTags(VALID_TAG_FRIEND).build();
+        descriptor = new EditPersonDescriptorBuilder().withTags(VALID_TAG_FRIEND)
+                .withLastModifiedDateTime(DEFAULT_TEST_TIME).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -215,7 +225,8 @@ public class EditCommandParserTest {
         Index targetIndex = INDEX_THIRD_PERSON;
         String userInput = targetIndex.getOneBased() + TAG_EMPTY;
 
-        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withTags().build();
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()
+                .withTags().withLastModifiedDateTime(DEFAULT_TEST_TIME).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -52,8 +52,6 @@ import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 
-import java.time.LocalDateTime;
-
 public class EditCommandParserTest {
 
     private static final String TAG_EMPTY = " " + PREFIX_TAG;

--- a/src/test/java/seedu/address/model/person/LastModifiedDateTimeTest.java
+++ b/src/test/java/seedu/address/model/person/LastModifiedDateTimeTest.java
@@ -2,8 +2,10 @@ package seedu.address.model.person;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.ClockUtil.DEFAULT_TEST_TIME;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -28,8 +30,6 @@ class LastModifiedDateTimeTest {
         assertThrows(NullPointerException.class, () -> LastModifiedDateTime.fromString(null));
     }
 
-
-
     @Test
     public void isValidLastModifiedDateTime() {
         // null job
@@ -45,14 +45,15 @@ class LastModifiedDateTimeTest {
         assertFalse(LastModifiedDateTime.isValidLastModifiedDateTime("1 Jan 1999, 24:09:00"));
         // another invalid field
         assertFalse(LastModifiedDateTime.isValidLastModifiedDateTime(
-                LastModifiedDateTime.DEFAULT_LAST_MODIFIED.format(
+                DEFAULT_TEST_TIME.format(
                         DateTimeFormatter.ISO_LOCAL_DATE_TIME)));
         // Valid input, but in wrong format
+        assertFalse(LastModifiedDateTime.isValidLastModifiedDateTime("1 Jan, 1999 10:09:00"));
 
         // valid LastModifiedDateTimes
         assertTrue(LastModifiedDateTime.isValidLastModifiedDateTime("1 Jan 1999, 10:09:00"));
         assertTrue(LastModifiedDateTime.isValidLastModifiedDateTime(
-                LastModifiedDateTime.DEFAULT_LAST_MODIFIED.format(
+                DEFAULT_TEST_TIME.format(
                         LastModifiedDateTime.LASTMODIFIED_FORMATTER)));
     }
 
@@ -73,13 +74,24 @@ class LastModifiedDateTimeTest {
         assertFalse(lastModifiedDateTime.equals(5.0f));
 
         // different values -> returns false
-        assertFalse(lastModifiedDateTime.equals(new Job("Other Valid Job")));
+        assertFalse(lastModifiedDateTime.equals(new LastModifiedDateTime(LocalDateTime.MIN)));
+    }
+
+    @Test
+    public void equals_extraPrecision_true() {
+        // Test for equality on extra precision, which we should drop. Precision is to seconds only.
+        LastModifiedDateTime lastModifiedDateTime= new LastModifiedDateTime(DEFAULT_TEST_TIME);
+        LastModifiedDateTime testDateTime = new LastModifiedDateTime(DEFAULT_TEST_TIME.minusNanos(1));
+        assertEquals(lastModifiedDateTime,testDateTime);
+
+        // But the raw LocalDateTimes should be non-equal
+        assertNotEquals(DEFAULT_TEST_TIME,DEFAULT_TEST_TIME.minusNanos(1));
     }
 
     @Test
     public void toStringMethod() {
-        assertEquals(new LastModifiedDateTime(LastModifiedDateTime.DEFAULT_LAST_MODIFIED).toString(),
-                LastModifiedDateTime.DEFAULT_LAST_MODIFIED.format(LastModifiedDateTime.LASTMODIFIED_FORMATTER));
+        assertEquals(new LastModifiedDateTime(DEFAULT_TEST_TIME).toString(),
+                DEFAULT_TEST_TIME.format(LastModifiedDateTime.LASTMODIFIED_FORMATTER));
         assertEquals(new LastModifiedDateTime(LocalDateTime.MAX).toString(),
                 LocalDateTime.MAX.format(LastModifiedDateTime.LASTMODIFIED_FORMATTER));
         assertEquals(new LastModifiedDateTime(LocalDateTime.MIN).toString(),

--- a/src/test/java/seedu/address/model/person/LastModifiedDateTimeTest.java
+++ b/src/test/java/seedu/address/model/person/LastModifiedDateTimeTest.java
@@ -80,12 +80,12 @@ class LastModifiedDateTimeTest {
     @Test
     public void equals_extraPrecision_true() {
         // Test for equality on extra precision, which we should drop. Precision is to seconds only.
-        LastModifiedDateTime lastModifiedDateTime= new LastModifiedDateTime(DEFAULT_TEST_TIME);
+        LastModifiedDateTime lastModifiedDateTime = new LastModifiedDateTime(DEFAULT_TEST_TIME);
         LastModifiedDateTime testDateTime = new LastModifiedDateTime(DEFAULT_TEST_TIME.minusNanos(1));
-        assertEquals(lastModifiedDateTime,testDateTime);
+        assertEquals(lastModifiedDateTime, testDateTime);
 
         // But the raw LocalDateTimes should be non-equal
-        assertNotEquals(DEFAULT_TEST_TIME,DEFAULT_TEST_TIME.minusNanos(1));
+        assertNotEquals(DEFAULT_TEST_TIME, DEFAULT_TEST_TIME.minusNanos(1));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/ClockUtil.java
+++ b/src/test/java/seedu/address/testutil/ClockUtil.java
@@ -1,0 +1,14 @@
+package seedu.address.testutil;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+public class ClockUtil {
+    private static final Instant TEST_CLOCK_TIME = Instant.from(ZonedDateTime.of(LocalDateTime.of(
+            2000,10,10,10,10,10,10),ZoneId.systemDefault()));
+    public static final Clock DEFAULT_TEST_CLOCK = Clock.fixed(TEST_CLOCK_TIME,ZoneId.systemDefault());
+    public static final LocalDateTime DEFAULT_TEST_TIME = LocalDateTime.now(DEFAULT_TEST_CLOCK);
+}

--- a/src/test/java/seedu/address/testutil/ClockUtil.java
+++ b/src/test/java/seedu/address/testutil/ClockUtil.java
@@ -11,4 +11,10 @@ public class ClockUtil {
             2000,10,10,10,10,10,10),ZoneId.systemDefault()));
     public static final Clock DEFAULT_TEST_CLOCK = Clock.fixed(TEST_CLOCK_TIME,ZoneId.systemDefault());
     public static final LocalDateTime DEFAULT_TEST_TIME = LocalDateTime.now(DEFAULT_TEST_CLOCK);
+
+    private static final Instant OTHER_CLOCK_TIME = Instant.from(ZonedDateTime.of(LocalDateTime.of(
+            2020,10,10,10,10,10,10),ZoneId.systemDefault()));
+
+    public static final Clock OTHER_TEST_CLOCK = Clock.fixed(OTHER_CLOCK_TIME,ZoneId.systemDefault());
+    public static final LocalDateTime OTHER_TEST_TIME = LocalDateTime.now(OTHER_TEST_CLOCK);
 }

--- a/src/test/java/seedu/address/testutil/ClockUtil.java
+++ b/src/test/java/seedu/address/testutil/ClockUtil.java
@@ -6,15 +6,20 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
+/**
+ * A utility class storing constants relating to clocks & time
+ */
 public class ClockUtil {
     private static final Instant TEST_CLOCK_TIME = Instant.from(ZonedDateTime.of(LocalDateTime.of(
-            2000,10,10,10,10,10,10),ZoneId.systemDefault()));
-    public static final Clock DEFAULT_TEST_CLOCK = Clock.fixed(TEST_CLOCK_TIME,ZoneId.systemDefault());
+            2000, 10, 10, 10, 10, 10, 10),
+            ZoneId.systemDefault()));
+    public static final Clock DEFAULT_TEST_CLOCK = Clock.fixed(TEST_CLOCK_TIME, ZoneId.systemDefault());
     public static final LocalDateTime DEFAULT_TEST_TIME = LocalDateTime.now(DEFAULT_TEST_CLOCK);
 
     private static final Instant OTHER_CLOCK_TIME = Instant.from(ZonedDateTime.of(LocalDateTime.of(
-            2020,10,10,10,10,10,10),ZoneId.systemDefault()));
+            2020, 10, 10, 10, 10, 10, 10),
+            ZoneId.systemDefault()));
 
-    public static final Clock OTHER_TEST_CLOCK = Clock.fixed(OTHER_CLOCK_TIME,ZoneId.systemDefault());
+    public static final Clock OTHER_TEST_CLOCK = Clock.fixed(OTHER_CLOCK_TIME, ZoneId.systemDefault());
     public static final LocalDateTime OTHER_TEST_TIME = LocalDateTime.now(OTHER_TEST_CLOCK);
 }

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -1,5 +1,6 @@
 package seedu.address.testutil;
 
+import java.time.LocalDateTime;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -8,6 +9,7 @@ import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.model.person.Company;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Job;
+import seedu.address.model.person.LastModifiedDateTime;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -39,6 +41,7 @@ public class EditPersonDescriptorBuilder {
         descriptor.setCompany(person.getCompany());
         descriptor.setJob(person.getJob());
         descriptor.setTags(person.getTags());
+        descriptor.setLastModifiedDateTime(person.getLastModifiedDateTime());
     }
 
     /**
@@ -88,6 +91,14 @@ public class EditPersonDescriptorBuilder {
     public EditPersonDescriptorBuilder withTags(String... tags) {
         Set<Tag> tagSet = Stream.of(tags).map(Tag::new).collect(Collectors.toSet());
         descriptor.setTags(tagSet);
+        return this;
+    }
+
+    /**
+     * Sets the {@code LastModifiedDateTime} of the {@code EditPersonDescriptor} that we are building.
+     */
+    public EditPersonDescriptorBuilder withLastModifiedDateTime(LocalDateTime lastModifiedDateTime) {
+        descriptor.setLastModifiedDateTime(new LastModifiedDateTime(lastModifiedDateTime));
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -1,5 +1,7 @@
 package seedu.address.testutil;
 
+import static seedu.address.testutil.ClockUtil.DEFAULT_TEST_TIME;
+
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Set;
@@ -14,7 +16,7 @@ import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.util.SampleDataUtil;
 
-import static seedu.address.testutil.ClockUtil.DEFAULT_TEST_TIME;
+
 
 
 /**

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -14,6 +14,7 @@ import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.util.SampleDataUtil;
 
+import static seedu.address.testutil.ClockUtil.DEFAULT_TEST_TIME;
 
 
 /**
@@ -27,7 +28,7 @@ public class PersonBuilder {
     public static final String DEFAULT_COMPANY = "Mandai Wildlife Group";
     public static final String DEFAULT_JOB = "Machine Learning Analyst";
 
-    public static final LocalDateTime DEFAULT_LAST_MODIFIED = LastModifiedDateTime.DEFAULT_LAST_MODIFIED;
+    public static final LocalDateTime DEFAULT_LAST_MODIFIED = DEFAULT_TEST_TIME;
 
     private Name name;
     private Phone phone;


### PR DESCRIPTION
> In order to properly support this does the following :
> 
> 1. Adds `Clock`-keeping to relevant commands, as well as `Model`, and by extension `Logic`. Semantically, this still makes sense, as these classes are in charge of the overall system, which would reasonably need to keep time in order to timestamp entries.
> 2. Expose API methods to set & get the `Clock` used.
> 3. Initialises previously-added field in [Creates LastModifiedDateTime field in Person #124](https://github.com/AY2324S1-CS2103-F13-1/tp/pull/124) to be time-stamped whenever `add` or `edit` is executed.
> 
> Does NOT :
> 
> 1. Expose user interface to change clock used. Consider as a future possible addition.
> 2. Allow for serialisation of clock used. Currently, just uses system default.
> 
> Test cases as amended/added in this PR were all passed on my machine.
> 
> Closes #111.

From #126 