### PR TITLE
Edit UserGuide and DeveloperGuide

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -271,21 +271,21 @@ _{Explain here how the data archiving feature will be implemented}_
 
 Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unlikely to have) - `*`
 
-| Priority | As a(n) …​     | I want to …​                                         | So that I can…​                                            |
-|----------|----------------|------------------------------------------------------|------------------------------------------------------------|
-| `* * *`  | user           | get text feedback for each line                      | know when the command is received                          |
-| `* * *`  | user           | get error feedback on a wrong command                | know what went wrong                                       |
-| `* * *`  | user           | delete a contact                                     | remove entries that I no longer need                       |
-| `* * *`  | user           | enter a new contact & their info                     |                                                            |
-| `* * *`  | user           | tag contacts                                         | organise contacts better                                   |
-| `* * *`  | user           | view contacts                                        |                                                            |
-| `* *`    | user           | be able to setup the app quickly                     |                                                            |
-| `* *`    | impatient user | have desired information viewable right on my screen | avoid having to search for what I'm looking for            |
-| `* *`    | user           | mark companies/contacts I've applied to              | avoid applying to the same company/contact twice           |
-| `* *`    | impatient user | filter/search for contacts                           | narrow down to just contacts I want to look at immediately |
-| `* *`    | impatient user | easily view the user guide                           | reference how to use the app                               |
-| `*`      | TBA            | TBA                                                  | TBA                                                        |
-| `*`      | TBA            | TBA                                                  | TBA                                                        |
+| Priority | As a(n) …​      | I want to …​                                            | So that I can…​                                            |
+|----------|-----------------|---------------------------------------------------------|------------------------------------------------------------|
+| `* * *`  | user            | get text feedback for each line                         | know when the command is received                          |
+| `* * *`  | user            | get error feedback on a wrong command                   | know what went wrong                                       |
+| `* * *`  | user            | delete a contact                                        | remove entries that I no longer need                       |
+| `* * *`  | user            | enter a new contact & their info                        |                                                            |
+| `* * *`  | user            | tag contacts                                            | organise contacts better                                   |
+| `* * *`  | user            | view contacts                                           |                                                            |
+| `* *`    | user            | be able to setup the app quickly                        |                                                            |
+| `* *`    | impatient user  | have desired information viewable right on my screen    | avoid having to search for what I'm looking for            |
+| `* *`    | user            | mark companies/contacts I've applied to                 | avoid applying to the same company/contact twice           |
+| `* *`    | impatient user  | filter/search for contacts                              | narrow down to just contacts I want to look at immediately |
+| `* *`    | impatient user  | easily view the user guide                              | reference how to use the app                               |
+| `*`      | user            | view the date/time of when a contact was added/modified | know when I added/edited the contact to the list           |
+| `*`      | TBA             | TBA                                                     | TBA                                                        |
 
 *{More to be added}*
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -15,7 +15,7 @@ title: User Guide
     * [Locating persons by name : `find`](#locating-persons-by-name--find)
     * [Marking contacts of interest : `mark`](#marking-contacts-of-interest--mark)
     * [Un-marking contacts of interest : `unmark`](#un-marking-contacts-of-interest--unmark)
-    * [Filtering a contact by tags : `filter`](#filtering-a-contact-by-tags--filter)
+    * [Filtering a contact via a specified field : `filter`](#filtering-a-contact-via-a-specified-field--filter)
     * [Deleting a contact : `delete`](#deleting-a-contact--delete)
     * [Clearing all entries : `clear`](#clearing-all-entries--clear)
     * [Exiting the program : `exit`](#exiting-the-program--exit)
@@ -169,14 +169,16 @@ Format: `unmark INDEX`
 Examples:
 * `unmark 1` un-marks the 1st person in the current displayed list.
 
-### Filtering a contact by tags : `filter`
+### Filtering a contact via a specified field : `filter`
 
-Displays all entries filtered by a specified tag.
+Displays all entries filtered via a specified field.
 
-Format: `filter FIELD/KEYWORD [MORE_KEYWORDS]`
+Format: `filter FIELD_PREFIX KEYWORD [MORE_KEYWORDS]`
 
-* FIELD: represents the tag to filter by.
-    * Example: if filter by company, then FIELD = “c”.
+* FIELD_PREFIX: represents the field to filter by.
+    * Example: if filter by company, FIELD_PREFIX = “c/”.
+* Only supports filtering via ONE field.
+    * Everything after FIELD_PREFIX will be recognized as keywords, including field prefixes!
 * The search is case-insensitive. e.g. `google` will match `Google`.
 * The order of the keywords does not matter. e.g. `Google Meta` will match `Meta Google`.
 * Only returns results with FULL matching keywords to the field.
@@ -224,29 +226,29 @@ Format: `exit`
 
 ## Command summary
 
-| Action     | Format, Examples                                                                                                                                                                             |
-|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Add**    | `add n/NAME p/PHONE_NUMBER e/EMAIL c/COMPANY j/JOB [t/TAG]...​`<br>e.g., `add n/John Wick p/12345678 e/johnwick@gmail.com c/Google j/Software Engineer t/NUS Alumni t/Met in Google Hackathon` |
-| **Clear**  | `clear`                                                                                                                                                                                      |
-| **Delete** | `delete INDEX`<br> e.g., `delete 2`                                                                                                                                                          |
-| **Edit**   | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`<br> e.g.,`edit 1 n/John Sick p/87654321 t/`                                                                           |
-| **Filter** | `filter FIELD KEYWORD [MORE_KEYWORDS]` <br> e.g., `filter c/Google`                                                                                                                          |
-| **Find**   | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find alex Young`                                                                                                                                   |
-| **List**   | `list`                                                                                                                                                                                       |
-| **Help**   | `help`                                                                                                                                                                                       |
-| **Mark**   | `mark INDEX` <br> e.g., `mark 2`                                                                                                                                                             |
-| **Unmark** | `unmark INDEX` <br> e.g., `unmark 1`                                                                                                                                                         |
+| Action     | Format, Examples                                                                                                                                                                                |
+|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Add**    | `add n/NAME p/PHONE_NUMBER e/EMAIL c/COMPANY j/JOB [t/TAG]...​`<br>e.g., `add n/John Wick p/12345678 e/johnwick@gmail.com c/Google j/Software Engineer t/NUS Alumni t/Met in Google Hackathon`  |
+| **Clear**  | `clear`                                                                                                                                                                                         |
+| **Delete** | `delete INDEX`<br> e.g., `delete 2`                                                                                                                                                             |
+| **Edit**   | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`<br> e.g.,`edit 1 n/John Sick p/87654321 t/`                                                                              |
+| **Filter** | `filter FIELD KEYWORD [MORE_KEYWORDS]` <br> e.g., `filter c/Google`                                                                                                                             |
+| **Find**   | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find alex Young`                                                                                                                                      |
+| **List**   | `list`                                                                                                                                                                                          |
+| **Help**   | `help`                                                                                                                                                                                          |
+| **Mark**   | `mark INDEX` <br> e.g., `mark 2`                                                                                                                                                                |
+| **Unmark** | `unmark INDEX` <br> e.g., `unmark 1`                                                                                                                                                            |
 
 --------------------------------------------------------------------------------------------------------------------
 
 ## Command FIELD Summary
 
-| Tag | Description  | Notes                                                |
-|-----|--------------|------------------------------------------------------|
-| c/  | COMPANY      | -                                                    |
-| e/  | EMAIL        | -                                                    |
-| j/  | JOB          | -                                                    |
-| n/  | NAME         | -                                                    |
-| p/  | PHONE_NUMBER | -                                                    |
-| t/  | TAG          | Multiple instances of this argument can be accepted. |
+| Prefix | Description  | Notes                                                |
+|--------|--------------|------------------------------------------------------|
+| c/     | COMPANY      | -                                                    |
+| e/     | EMAIL        | -                                                    |
+| j/     | JOB          | -                                                    |
+| n/     | NAME         | -                                                    |
+| p/     | PHONE_NUMBER | -                                                    |
+| t/     | TAG          | Multiple instances of this argument can be accepted. |
 


### PR DESCRIPTION
Add user story of datetime in developer guide.
More clarification of `filter` command in user guide.
Replace `tags` with `prefix` to avoid confusion with the actual tags.

Closes #128 