### PR TITLE
Add mark and unmark command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkCommand.java
@@ -1,0 +1,44 @@
+package seedu.address.logic.commands;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class MarkCommand extends Command{
+    public static final String COMMAND_WORD = "mark";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Marks the person identified by the index number used in the displayed person list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_MARK_SUCCESS = "Marked Person: %1$s";
+
+    private final Index targetIndex;
+
+    public MarkCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToMark = lastShownList.get(targetIndex.getZeroBased());
+        model.markPerson(personToMark);
+        return new CommandResult(String.format(MESSAGE_MARK_SUCCESS, Messages.format(personToMark)));
+    }
+
+
+}

--- a/src/main/java/seedu/address/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkCommand.java
@@ -1,5 +1,9 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
@@ -7,8 +11,6 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 
-import java.util.List;
-import static java.util.Objects.requireNonNull;
 
 /**
  * Marks a person identified using it's displayed index from the address book.

--- a/src/main/java/seedu/address/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkCommand.java
@@ -8,7 +8,6 @@ import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 
 import java.util.List;
-
 import static java.util.Objects.requireNonNull;
 
 /**

--- a/src/main/java/seedu/address/logic/commands/UnMarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnMarkCommand.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.commands;
 
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
@@ -12,20 +13,20 @@ import java.util.List;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Marks a person identified using it's displayed index from the address book.
+ * UnMarks a person identified using it's displayed index from the address book.
  */
-public class MarkCommand extends Command {
-    public static final String COMMAND_WORD = "mark";
+public class UnMarkCommand extends Command{
+    public static final String COMMAND_WORD = "unmark";
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Marks the person identified by the index number used in the displayed person list.\n"
+            + ": Un-marks the person identified by the index number used in the displayed person list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_MARK_SUCCESS = "Marked Person: %1$s";
+    public static final String MESSAGE_UNMARK_SUCCESS = "Un-marked Person: %1$s";
 
     private final Index targetIndex;
 
-    public MarkCommand(Index targetIndex) {
+    public UnMarkCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
     }
 
@@ -39,23 +40,22 @@ public class MarkCommand extends Command {
         }
 
         Person personToMark = lastShownList.get(targetIndex.getZeroBased());
-        model.markPerson(personToMark);
-        return new CommandResult(String.format(MESSAGE_MARK_SUCCESS, Messages.format(personToMark)));
+        model.unMarkPerson(personToMark);
+        return new CommandResult(String.format(MESSAGE_UNMARK_SUCCESS, Messages.format(personToMark)));
     }
 
-    @Override
     public boolean equals(Object other) {
         if (other == this) {
             return true;
         }
 
         // instanceof handles nulls
-        if (!(other instanceof MarkCommand)) {
+        if (!(other instanceof UnMarkCommand)) {
             return false;
         }
 
-        MarkCommand otherMarkCommand = (MarkCommand) other;
-        return targetIndex.equals(otherMarkCommand.targetIndex);
+        UnMarkCommand otherUnMarkCommand = (UnMarkCommand) other;
+        return targetIndex.equals(otherUnMarkCommand.targetIndex);
     }
 
     @Override
@@ -65,4 +65,3 @@ public class MarkCommand extends Command {
                 .toString();
     }
 }
-

--- a/src/main/java/seedu/address/logic/commands/UnMarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnMarkCommand.java
@@ -39,9 +39,9 @@ public class UnMarkCommand extends Command{
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
-        Person personToMark = lastShownList.get(targetIndex.getZeroBased());
-        model.unMarkPerson(personToMark);
-        return new CommandResult(String.format(MESSAGE_UNMARK_SUCCESS, Messages.format(personToMark)));
+        Person personToUnMark = lastShownList.get(targetIndex.getZeroBased());
+        model.unMarkPerson(personToUnMark);
+        return new CommandResult(String.format(MESSAGE_UNMARK_SUCCESS, Messages.format(personToUnMark)));
     }
 
     public boolean equals(Object other) {

--- a/src/main/java/seedu/address/logic/commands/UnMarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnMarkCommand.java
@@ -1,5 +1,8 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.ToStringBuilder;
@@ -8,14 +11,10 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 
-import java.util.List;
-
-import static java.util.Objects.requireNonNull;
-
 /**
  * UnMarks a person identified using it's displayed index from the address book.
  */
-public class UnMarkCommand extends Command{
+public class UnMarkCommand extends Command {
     public static final String COMMAND_WORD = "unmark";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Un-marks the person identified by the index number used in the displayed person list.\n"
@@ -44,6 +43,7 @@ public class UnMarkCommand extends Command{
         return new CommandResult(String.format(MESSAGE_UNMARK_SUCCESS, Messages.format(personToUnMark)));
     }
 
+    @Override
     public boolean equals(Object other) {
         if (other == this) {
             return true;

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -9,16 +9,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.ClearCommand;
-import seedu.address.logic.commands.Command;
-import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.ExitCommand;
-import seedu.address.logic.commands.FilterCommand;
-import seedu.address.logic.commands.FindCommand;
-import seedu.address.logic.commands.HelpCommand;
-import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.*;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -77,7 +68,8 @@ public class AddressBookParser implements ClockDependantParser<Command> {
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();
-
+        case MarkCommand.COMMAND_WORD:
+            return new MarkCommandParser().parse(arguments);
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -68,8 +68,13 @@ public class AddressBookParser implements ClockDependantParser<Command> {
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();
+
         case MarkCommand.COMMAND_WORD:
             return new MarkCommandParser().parse(arguments);
+
+        case UnMarkCommand.COMMAND_WORD:
+            return new UnMarkCommandParser().parse(arguments);
+
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -9,7 +9,18 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.logic.commands.*;
+import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FilterCommand;
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.MarkCommand;
+import seedu.address.logic.commands.UnMarkCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**

--- a/src/main/java/seedu/address/logic/parser/MarkCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MarkCommandParser.java
@@ -1,0 +1,32 @@
+package seedu.address.logic.parser;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.MarkCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+
+import java.util.Arrays;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+/**
+ * Parses input arguments and creates a new MarkCommand object
+ */
+public class MarkCommandParser implements Parser<MarkCommand>{
+    /**
+     * Parses the given {@code String} of arguments in the context of the MarkCommand
+     * and returns a MarkCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public MarkCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new MarkCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/MarkCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MarkCommandParser.java
@@ -1,20 +1,15 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.MarkCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
-
-import java.util.Arrays;
-
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 /**
  * Parses input arguments and creates a new MarkCommand object
  */
-public class MarkCommandParser implements Parser<MarkCommand>{
+public class MarkCommandParser implements Parser<MarkCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the MarkCommand
      * and returns a MarkCommand object for execution.

--- a/src/main/java/seedu/address/logic/parser/UnMarkCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnMarkCommandParser.java
@@ -1,15 +1,15 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.UnMarkCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-
 /**
  * Parses input arguments and creates a new UnMarkCommand object
  */
-public class UnMarkCommandParser implements Parser<UnMarkCommand>{
+public class UnMarkCommandParser implements Parser<UnMarkCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the UnMarkCommand
      * and returns a UnMarkCommand object for execution.

--- a/src/main/java/seedu/address/logic/parser/UnMarkCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnMarkCommandParser.java
@@ -1,0 +1,27 @@
+package seedu.address.logic.parser;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.UnMarkCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+/**
+ * Parses input arguments and creates a new UnMarkCommand object
+ */
+public class UnMarkCommandParser implements Parser<UnMarkCommand>{
+    /**
+     * Parses the given {@code String} of arguments in the context of the UnMarkCommand
+     * and returns a UnMarkCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public UnMarkCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new UnMarkCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnMarkCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -103,6 +103,15 @@ public class AddressBook implements ReadOnlyAddressBook {
         key.mark();
     }
 
+    /**
+     * unMarks {@code key} from this {@code AddressBook}.
+     * {@code key} must exist in the address book.
+     */
+    public void unMarkPerson(Person key) {
+        requireNonNull(key);
+        key.unMark();
+    }
+
     //// util methods
 
     @Override
@@ -136,4 +145,5 @@ public class AddressBook implements ReadOnlyAddressBook {
     public int hashCode() {
         return persons.hashCode();
     }
+
 }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -82,9 +82,6 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void setPerson(Person target, Person editedPerson) {
         requireNonNull(editedPerson);
-        if (target.getMarkStatus().toString().equals("\u2605")) {
-            editedPerson.mark();
-        }
         persons.setPerson(target, editedPerson);
     }
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -82,7 +82,9 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void setPerson(Person target, Person editedPerson) {
         requireNonNull(editedPerson);
-
+        if (target.getMarkStatus().toString().equals("\u2605")) {
+            editedPerson.mark();
+        }
         persons.setPerson(target, editedPerson);
     }
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -94,6 +94,15 @@ public class AddressBook implements ReadOnlyAddressBook {
         persons.remove(key);
     }
 
+    /**
+     * marks {@code key} from this {@code AddressBook}.
+     * {@code key} must exist in the address book.
+     */
+    public void markPerson(Person key) {
+        requireNonNull(key);
+        key.mark();
+    }
+
     //// util methods
 
     @Override

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -14,6 +14,7 @@ import seedu.address.model.person.Person;
 public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
+    Predicate<Person> PREDICATE_SHOW_NO_PERSONS = unused -> false;
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -95,4 +95,10 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /**
+     * Marks the given person.
+     * The person must exist in the address book.
+     */
+    void markPerson(Person target);
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -101,4 +101,10 @@ public interface Model {
      * The person must exist in the address book.
      */
     void markPerson(Person target);
+
+    /**
+     * Un-Marks the given person.
+     * The person must exist in the address book.
+     */
+    void unMarkPerson(Person target);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -74,7 +74,6 @@ public class ModelManager implements Model {
         userPrefs.setGuiSettings(guiSettings);
     }
 
-
     @Override
     public void setClock(Clock clock) {
         this.clock = clock;
@@ -124,6 +123,10 @@ public class ModelManager implements Model {
         addressBook.markPerson(person);
     }
 
+    @Override
+    public void unMarkPerson(Person person) {
+        addressBook.unMarkPerson(person);
+    }
 
     @Override
     public void addPerson(Person person) {

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -120,6 +120,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void markPerson(Person person) {
+        addressBook.markPerson(person);
+    }
+
+
+    @Override
     public void addPerson(Person person) {
         addressBook.addPerson(person);
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -121,11 +121,15 @@ public class ModelManager implements Model {
     @Override
     public void markPerson(Person person) {
         addressBook.markPerson(person);
+        updateFilteredPersonList(PREDICATE_SHOW_NO_PERSONS);
+        updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
 
     @Override
     public void unMarkPerson(Person person) {
         addressBook.unMarkPerson(person);
+        updateFilteredPersonList(PREDICATE_SHOW_NO_PERSONS);
+        updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
 
     @Override
@@ -137,9 +141,9 @@ public class ModelManager implements Model {
     @Override
     public void setPerson(Person target, Person editedPerson) {
         requireAllNonNull(target, editedPerson);
-
         addressBook.setPerson(target, editedPerson);
     }
+
 
     //=========== Filtered Person List Accessors =============================================================
 

--- a/src/main/java/seedu/address/model/person/Mark.java
+++ b/src/main/java/seedu/address/model/person/Mark.java
@@ -1,0 +1,68 @@
+package seedu.address.model.person;
+
+import seedu.address.logic.commands.DeleteCommand;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Represents a Recipe's favourite status in the recipe book.
+ * Guarantees: mutable.
+ */
+public class Mark {
+    public static final String MESSAGE_CONSTRAINTS =
+            "Favourites can only be true or false!";
+
+    private boolean markStatus;
+
+    /**
+     * Constructs a Fav Object.
+     * @param status true or false.
+     */
+    public Mark(boolean status) {
+        requireNonNull(status);
+        this.markStatus = status;
+    }
+
+    public void mark() {
+        this.markStatus = true;
+    }
+
+    public void unMark() {
+        this.markStatus = false;
+    }
+
+    public boolean getMarkStatus() {
+        return markStatus;
+    }
+
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof Mark)) {
+            return false;
+        }
+
+        return markStatus == ((Mark) other).markStatus;
+    }
+
+
+    @Override
+    public String toString() {
+        if (markStatus == true) {
+            return "\u2605";
+        } else {
+            return "\u2606";
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return String.valueOf(markStatus).hashCode();
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/Mark.java
+++ b/src/main/java/seedu/address/model/person/Mark.java
@@ -1,21 +1,19 @@
 package seedu.address.model.person;
 
-import seedu.address.logic.commands.DeleteCommand;
-
 import static java.util.Objects.requireNonNull;
 
 /**
- * Represents a Recipe's favourite status in the recipe book.
+ * Represents the mark status in the address book.
  * Guarantees: mutable.
  */
 public class Mark {
     public static final String MESSAGE_CONSTRAINTS =
-            "Favourites can only be true or false!";
+            "Mark Status can only be true or false!";
 
     private boolean markStatus;
 
     /**
-     * Constructs a Fav Object.
+     * Constructs Mark Object.
      * @param status true or false.
      */
     public Mark(boolean status) {
@@ -30,11 +28,6 @@ public class Mark {
     public void unMark() {
         this.markStatus = false;
     }
-
-    public boolean getMarkStatus() {
-        return markStatus;
-    }
-
 
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/address/model/person/Mark.java
+++ b/src/main/java/seedu/address/model/person/Mark.java
@@ -47,9 +47,9 @@ public class Mark {
     @Override
     public String toString() {
         if (markStatus == true) {
-            return "\u2605";
+            return "\u2605"; //★
         } else {
-            return "\u2606";
+            return "\u2606"; //☆
         }
     }
 

--- a/src/main/java/seedu/address/model/person/Mark.java
+++ b/src/main/java/seedu/address/model/person/Mark.java
@@ -16,7 +16,7 @@ public class Mark {
      * Constructs Mark Object.
      * @param status true or false.
      */
-    public Mark(boolean status) {
+    public Mark(Boolean status) {
         requireNonNull(status);
         this.markStatus = status;
     }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -26,6 +26,7 @@ public class Person {
     private final Job job;
     private final Set<Tag> tags = new HashSet<>();
 
+    private final Mark markStatus = new Mark(false);
     private final LastModifiedDateTime lastModifiedDateTime;
 
     /**
@@ -62,6 +63,7 @@ public class Person {
     public Job getJob() {
         return job;
     }
+    public Mark getMarkStatus() {return markStatus;}
 
     public LastModifiedDateTime getLastModifiedDateTime() {
         return lastModifiedDateTime;
@@ -88,6 +90,10 @@ public class Person {
                 && otherPerson.getName().equals(getName());
     }
 
+    public void mark() {
+        markStatus.mark();
+    }
+
     /**
      * Returns true if both persons have the same identity and data fields.
      * This defines a stronger notion of equality between two persons.
@@ -110,6 +116,7 @@ public class Person {
                 && company.equals(otherPerson.company)
                 && job.equals(otherPerson.job)
                 && tags.equals(otherPerson.tags)
+                && markStatus.equals(otherPerson.markStatus)
                 && lastModifiedDateTime.equals(otherPerson.lastModifiedDateTime);
     }
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -89,8 +89,18 @@ public class Person {
                 && otherPerson.getName().equals(getName());
     }
 
+    /**
+     * Marks a person's markStatus as true.
+     */
     public void mark() {
         markStatus.mark();
+    }
+
+    /**
+     * Marks a person's markStatus as false.
+     */
+    public void unMark() {
+        markStatus.unMark();
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -62,7 +62,7 @@ public class Person {
     public Job getJob() {
         return job;
     }
-    public Mark getMarkStatus() {return markStatus;}
+    public Mark getMarkStatus() { return markStatus; }
 
     public LastModifiedDateTime getLastModifiedDateTime() {
         return lastModifiedDateTime;

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -62,7 +62,9 @@ public class Person {
     public Job getJob() {
         return job;
     }
-    public Mark getMarkStatus() { return markStatus; }
+    public Mark getMarkStatus() {
+        return markStatus;
+    }
 
     public LastModifiedDateTime getLastModifiedDateTime() {
         return lastModifiedDateTime;

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -25,7 +25,6 @@ public class Person {
     private final Company company;
     private final Job job;
     private final Set<Tag> tags = new HashSet<>();
-
     private final Mark markStatus = new Mark(false);
     private final LastModifiedDateTime lastModifiedDateTime;
 

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -65,7 +65,7 @@ public class UniquePersonList implements Iterable<Person> {
             throw new DuplicatePersonException();
         }
 
-        if (target.getMarkStatus().toString().equals("\u2665") == true) {
+        if (target.getMarkStatus().toString().equals("\u2605")) {
             editedPerson.mark();
         }
 

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -64,11 +64,6 @@ public class UniquePersonList implements Iterable<Person> {
         if (!target.isSamePerson(editedPerson) && contains(editedPerson)) {
             throw new DuplicatePersonException();
         }
-
-        if (target.getMarkStatus().toString().equals("\u2605")) {
-            editedPerson.mark();
-        }
-
         internalList.set(index, editedPerson);
     }
 

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -65,6 +65,10 @@ public class UniquePersonList implements Iterable<Person> {
             throw new DuplicatePersonException();
         }
 
+        if (target.getMarkStatus().toString().equals("\u2665") == true) {
+            editedPerson.mark();
+        }
+
         internalList.set(index, editedPerson);
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -32,7 +32,7 @@ class JsonAdaptedPerson {
     private final String company;
     private final String job;
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
-
+    private final String mark;
     private final String lastModifiedDateTime;
 
     /**
@@ -42,6 +42,7 @@ class JsonAdaptedPerson {
     public JsonAdaptedPerson(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
             @JsonProperty("email") String email, @JsonProperty("company") String company,
             @JsonProperty("job") String job, @JsonProperty("tags") List<JsonAdaptedTag> tags,
+            @JsonProperty("mark") String mark,
             @JsonProperty("last_modified") String lastModifiedDateTime) {
         this.name = name;
         this.phone = phone;
@@ -51,6 +52,7 @@ class JsonAdaptedPerson {
         if (tags != null) {
             this.tags.addAll(tags);
         }
+        this.mark = mark;
         this.lastModifiedDateTime = lastModifiedDateTime;
     }
 
@@ -66,6 +68,7 @@ class JsonAdaptedPerson {
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
+        mark = source.getMarkStatus().toString();
         lastModifiedDateTime = source.getLastModifiedDateTime().toString();
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -72,6 +72,7 @@ class JsonAdaptedPerson {
         lastModifiedDateTime = source.getLastModifiedDateTime().toString();
     }
 
+
     /**
      * Converts this Jackson-friendly adapted person object into the model's {@code Person} object.
      *
@@ -123,8 +124,6 @@ class JsonAdaptedPerson {
         }
         final Job modelJob = new Job(job);
 
-
-
         if (lastModifiedDateTime == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     LastModifiedDateTime.class.getSimpleName()));
@@ -139,9 +138,11 @@ class JsonAdaptedPerson {
         final Set<Tag> modelTags = new HashSet<>(personTags);
 
         Person newPerson = new Person(modelName, modelPhone, modelEmail, modelCompany, modelJob, modelTags, lastModified);
+
         if (mark.equals("\u2605")) {
             newPerson.mark();
         }
+
         return newPerson;
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -123,6 +123,8 @@ class JsonAdaptedPerson {
         }
         final Job modelJob = new Job(job);
 
+
+
         if (lastModifiedDateTime == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     LastModifiedDateTime.class.getSimpleName()));
@@ -135,7 +137,12 @@ class JsonAdaptedPerson {
                 LastModifiedDateTime.fromString(lastModifiedDateTime);
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
-        return new Person(modelName, modelPhone, modelEmail, modelCompany, modelJob, modelTags, lastModified);
+
+        Person newPerson = new Person(modelName, modelPhone, modelEmail, modelCompany, modelJob, modelTags, lastModified);
+        if (mark.equals("\u2605")) {
+            newPerson.mark();
+        }
+        return newPerson;
     }
 
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -72,7 +72,6 @@ class JsonAdaptedPerson {
         lastModifiedDateTime = source.getLastModifiedDateTime().toString();
     }
 
-
     /**
      * Converts this Jackson-friendly adapted person object into the model's {@code Person} object.
      *
@@ -137,7 +136,8 @@ class JsonAdaptedPerson {
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
 
-        Person newPerson = new Person(modelName, modelPhone, modelEmail, modelCompany, modelJob, modelTags, lastModified);
+        Person newPerson = new Person(
+                modelName, modelPhone, modelEmail, modelCompany, modelJob, modelTags, lastModified);
 
         if (mark.equals("\u2605")) {
             newPerson.mark();

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -59,7 +59,7 @@ public class PersonCard extends UiPart<Region> {
         company.setText(person.getCompany().value);
         job.setText(person.getJob().value);
         email.setText(person.getEmail().value);
-        //markStatus.setText(person.getMarkStatus().toString());
+        markStatus.setText(person.getMarkStatus().toString());
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -41,6 +41,8 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label email;
     @FXML
+    private Label markStatus;
+    @FXML
     private FlowPane tags;
     @FXML
     private Label lastModifiedDateTime;
@@ -57,7 +59,7 @@ public class PersonCard extends UiPart<Region> {
         company.setText(person.getCompany().value);
         job.setText(person.getJob().value);
         email.setText(person.getEmail().value);
-
+        //markStatus.setText(person.getMarkStatus().toString());
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/resources/view/Extensions.css
+++ b/src/main/resources/view/Extensions.css
@@ -18,3 +18,10 @@
 .tooltip-text {
     -fx-text-fill: white;
 }
+
+.cell_icon_label {
+    -fx-font-family: "Segoe UI Light";
+    -fx-text-fill: #ffaa00;
+    -fx-font-size: 25px;
+    -fx-padding: 0 20 0 0
+}

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -32,6 +32,7 @@
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
       <Label fx:id="company" styleClass="cell_small_label" text="\$company" />
       <Label fx:id="job" styleClass="cell_small_label" text="\$job" />
+      <Label fx:id="markStatus" styleClass="cell_small_label" text="\$mark" />
       <Label fx:id="lastModifiedDateTime" styleClass="cell_small_label"
              style="-fx-font-style : italic " text="\$lastModifiedDateTime" />
     </VBox>

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -32,9 +32,13 @@
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
       <Label fx:id="company" styleClass="cell_small_label" text="\$company" />
       <Label fx:id="job" styleClass="cell_small_label" text="\$job" />
-      <Label fx:id="markStatus" styleClass="cell_small_label" text="\$mark" />
       <Label fx:id="lastModifiedDateTime" styleClass="cell_small_label"
              style="-fx-font-style : italic " text="\$lastModifiedDateTime" />
+    </VBox>
+    <VBox alignment="CENTER_RIGHT" prefHeight="94.0" prefWidth="200.0">
+      <children>
+        <Label fx:id="markStatus" styleClass="cell_icon_label" text="\$markStatus" />
+      </children>
     </VBox>
   </GridPane>
 </HBox>

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -6,6 +6,7 @@
     "company": "Directions Group",
     "job": "AI Engineer",
     "tags": [ "friends" ],
+    "mark": "\u2606",
     "last_modified" : "10 Oct 2000, 10:10:00"
   }, {
     "name": "Alice Pauline",
@@ -13,6 +14,7 @@
     "email": "pauline@example.com",
     "company": "Changi Airport Group",
     "job": "AI Engineer",
+    "mark": "\u2606",
     "last_modified" : "10 Oct 2000, 10:10:00"
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
@@ -5,6 +5,7 @@
     "email": "invalid@email!3e",
     "company": "SingStats",
     "job": "AI Engineer",
+    "mark": "\u2606",
     "last_modified" : "10 Oct 2000, 10:10:00"
   }, {
     "name" : "Fiona Kunz",
@@ -13,6 +14,7 @@
     "company": "Citadel",
     "job": "AI Engineer",
     "tags" : [ ],
+    "mark": "\u2606",
     "last_modified" : "40 Oct 2000, 10:10:00"
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -6,6 +6,7 @@
     "email" : "alice@example.com",
     "company": "Google",
     "job": "AI Analyst",
+    "mark": "\u2606",
     "tags" : [ "friends" ],
     "last_modified" : "10 Oct 2000, 10:10:10"
   }, {
@@ -14,6 +15,7 @@
     "email" : "johnd@example.com",
     "company": "Mandai Wildlife Group",
     "job": "Software Engineer",
+    "mark": "\u2606",
     "tags" : [ "owesMoney", "friends" ],
     "last_modified" : "10 Oct 2000, 10:10:10"
   }, {
@@ -23,6 +25,7 @@
     "company": "Grab",
     "job": "AI Engineer",
     "tags" : [ ],
+    "mark": "\u2606",
     "last_modified" : "10 Oct 2000, 10:10:10"
   }, {
     "name" : "Daniel Meier",
@@ -31,6 +34,7 @@
     "company": "Uber",
     "job": "Data Analyst",
     "tags" : [ "friends" ],
+    "mark": "\u2606",
     "last_modified" : "10 Oct 2000, 10:10:10"
   }, {
     "name" : "Elle Meyer",
@@ -39,6 +43,7 @@
     "company": "Central Provident Board",
     "job": "Machine Learning Analyst",
     "tags" : [ ],
+    "mark": "\u2606",
     "last_modified" : "10 Oct 2000, 10:10:10"
   }, {
     "name" : "Fiona Kunz",
@@ -47,6 +52,7 @@
     "company": "Citadel",
     "job": "AI Engineer",
     "tags" : [ ],
+    "mark": "\u2606",
     "last_modified" : "10 Oct 2000, 10:10:10"
   }, {
     "name" : "George Best",
@@ -55,6 +61,7 @@
     "company": "Morgan Stanley",
     "job": "Risk Analyst",
     "tags" : [ ],
+    "mark": "\u2606",
     "last_modified" : "10 Oct 2000, 10:10:10"
   } ]
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -175,6 +175,16 @@ public class AddCommandTest {
         public void updateFilteredPersonList(Predicate<Person> predicate) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public void markPerson(Person target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void unMarkPerson(Person target) {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/MarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkCommandTest.java
@@ -1,9 +1,13 @@
 package seedu.address.logic.commands;
 
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
@@ -38,6 +42,36 @@ public class MarkCommandTest {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
         MarkCommand markCommand = new MarkCommand(outOfBoundIndex);
         assertCommandFailure(markCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        MarkCommand markFirstCommand = new MarkCommand(INDEX_FIRST_PERSON);
+        MarkCommand markSecondCommand = new MarkCommand(INDEX_SECOND_PERSON);
+
+        // same object -> returns true
+        assertTrue(markFirstCommand.equals(markFirstCommand));
+
+        // same values -> returns true
+        MarkCommand markFirstCommandCopy = new MarkCommand(INDEX_FIRST_PERSON);
+        assertTrue(markFirstCommand.equals(markFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(markFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(markFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(markFirstCommand.equals(markSecondCommand));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Index targetIndex = Index.fromOneBased(1);
+        MarkCommand markCommand = new MarkCommand(targetIndex);
+        String expected = MarkCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
+        assertEquals(expected, markCommand.toString());
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/MarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkCommandTest.java
@@ -1,0 +1,43 @@
+package seedu.address.logic.commands;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+
+import static seedu.address.logic.commands.CommandTestUtil.*;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+
+public class MarkCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Person personToMark = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        MarkCommand markCommand = new MarkCommand(INDEX_FIRST_PERSON);
+
+        String expectedMessage = String.format(MarkCommand.MESSAGE_MARK_SUCCESS,
+                Messages.format(personToMark));
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.markPerson(personToMark);
+
+        assertCommandSuccess(markCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        MarkCommand markCommand = new MarkCommand(outOfBoundIndex);
+        assertCommandFailure(markCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/MarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkCommandTest.java
@@ -1,16 +1,16 @@
 package seedu.address.logic.commands;
 
-import seedu.address.commons.core.index.Index;
-import seedu.address.logic.Messages;
-import seedu.address.model.Model;
 
-import static seedu.address.logic.commands.CommandTestUtil.*;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;

--- a/src/test/java/seedu/address/logic/commands/UnMarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnMarkCommandTest.java
@@ -1,0 +1,41 @@
+package seedu.address.logic.commands;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+public class UnMarkCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Person personToUnMark = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        UnMarkCommand unMarkCommand = new UnMarkCommand(INDEX_FIRST_PERSON);
+
+        String expectedMessage = String.format(UnMarkCommand.MESSAGE_UNMARK_SUCCESS,
+                Messages.format(personToUnMark));
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.markPerson(personToUnMark);
+
+        assertCommandSuccess(unMarkCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        UnMarkCommand unMarkCommand = new UnMarkCommand(outOfBoundIndex);
+        assertCommandFailure(unMarkCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/UnMarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnMarkCommandTest.java
@@ -1,17 +1,18 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
 import org.junit.jupiter.api.Test;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
-
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 public class UnMarkCommandTest {
 

--- a/src/test/java/seedu/address/logic/commands/UnMarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnMarkCommandTest.java
@@ -1,8 +1,12 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
@@ -38,5 +42,36 @@ public class UnMarkCommandTest {
         UnMarkCommand unMarkCommand = new UnMarkCommand(outOfBoundIndex);
         assertCommandFailure(unMarkCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
+
+    @Test
+    public void equals() {
+        UnMarkCommand unMarkFirstCommand = new UnMarkCommand(INDEX_FIRST_PERSON);
+        UnMarkCommand unMarkSecondCommand = new UnMarkCommand(INDEX_SECOND_PERSON);
+
+        // same object -> returns true
+        assertTrue(unMarkFirstCommand.equals(unMarkFirstCommand));
+
+        // same values -> returns true
+        UnMarkCommand unMarkFirstCommandCopy = new UnMarkCommand(INDEX_FIRST_PERSON);
+        assertTrue(unMarkFirstCommand.equals(unMarkFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(unMarkFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(unMarkFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(unMarkFirstCommand.equals(unMarkSecondCommand));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Index targetIndex = Index.fromOneBased(1);
+        UnMarkCommand unMarkCommand = new UnMarkCommand(targetIndex);
+        String expected = UnMarkCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
+        assertEquals(expected, unMarkCommand.toString());
+    }
+
 
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -25,6 +25,8 @@ import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.MarkCommand;
+import seedu.address.logic.commands.UnMarkCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.CompanyContainsKeywordsPredicate;
 import seedu.address.model.person.EmailContainsKeywordsPredicate;
@@ -135,6 +137,20 @@ public class AddressBookParserTest {
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_mark() throws Exception {
+        MarkCommand command = (MarkCommand) parser.parseCommand(
+                MarkCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
+        assertEquals(new MarkCommand(INDEX_FIRST_PERSON), command);
+    }
+
+    @Test
+    public void parseCommand_unMark() throws Exception {
+        UnMarkCommand command = (UnMarkCommand) parser.parseCommand(
+                UnMarkCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
+        assertEquals(new UnMarkCommand(INDEX_FIRST_PERSON), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/MarkCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/MarkCommandParserTest.java
@@ -1,0 +1,30 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.MarkCommand;
+
+
+public class MarkCommandParserTest {
+    private MarkCommandParser parser = new MarkCommandParser();
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsMarkCommand() {
+        assertParseSuccess(parser, "1", new MarkCommand(INDEX_FIRST_PERSON));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE));
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/UnMarkCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnMarkCommandParserTest.java
@@ -1,0 +1,28 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.UnMarkCommand;
+
+public class UnMarkCommandParserTest {
+    private UnMarkCommandParser parser = new UnMarkCommandParser();
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnMarkCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsMarkCommand() {
+        assertParseSuccess(parser, "1", new UnMarkCommand(INDEX_FIRST_PERSON));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnMarkCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/model/person/MarkTest.java
+++ b/src/test/java/seedu/address/model/person/MarkTest.java
@@ -1,0 +1,48 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class MarkTest {
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Mark(null));
+    }
+
+    @Test
+    public void equals() {
+        Mark mark = new Mark(true);
+
+        // same values -> returns true
+        assertTrue(mark.equals(new Mark(true)));
+
+        // same object -> returns true
+        assertTrue(mark.equals(mark));
+
+        // null -> returns false
+        assertFalse(mark.equals(null));
+
+        // different types -> returns false
+        assertFalse(mark.equals(5.0f));
+
+        // different values -> returns false
+        assertFalse(mark.equals(new Mark(false)));
+    }
+
+    @Test
+    public void toString_markedStatus() {
+        Mark markedMark = new Mark(true);
+        assertEquals("\u2605", markedMark.toString());
+    }
+
+    @Test
+    public void toString_unmarkedStatus() {
+        Mark unmarkedMark = new Mark(false);
+        assertEquals("\u2606", unmarkedMark.toString());
+    }
+
+}

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -1,6 +1,7 @@
 package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static seedu.address.storage.JsonAdaptedPerson.MISSING_FIELD_MESSAGE_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.BENSON;
@@ -17,6 +18,7 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Job;
 import seedu.address.model.person.LastModifiedDateTime;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 
 public class JsonAdaptedPersonTest {
@@ -169,4 +171,20 @@ public class JsonAdaptedPersonTest {
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 
+    @Test
+    public void toModelType_markedStatus_returnsmarkedPerson() throws Exception {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
+                VALID_COMPANY, VALID_JOB, VALID_TAGS, "\u2605", VALID_LAST_MODIFIED_DATE_TIME);
+        Person modelPerson = person.toModelType();
+        assertFalse(modelPerson.getMarkStatus().equals(true));
+    }
+    @Test
+    public void toModelType_unmarkedStatus_returnsUnmarkedPerson() throws Exception {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
+                VALID_COMPANY, VALID_JOB, VALID_TAGS, "\u2606", VALID_LAST_MODIFIED_DATE_TIME);
+        Person modelPerson = person.toModelType();
+        assertFalse(modelPerson.getMarkStatus().equals(false));
+    }
+
 }
+

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -27,17 +27,18 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
 
-    private static final String INVALID_LASTMODIFIEDDATETIME = "Nov 40, 2000 13:00:10 AM";
+    private static final String INVALID_LAST_MODIFIED_DATE_TIME = "Nov 40, 2000 13:00:10 AM";
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_PHONE = BENSON.getPhone().toString();
     private static final String VALID_EMAIL = BENSON.getEmail().toString();
     private static final String VALID_COMPANY = BENSON.getCompany().toString();
     private static final String VALID_JOB = BENSON.getJob().toString();
+    private static final String VALID_MARK_STATUS = BENSON.getMarkStatus().toString();
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
 
-    private static final String VALID_LASTMODIFIEDDATETIME = BENSON.getLastModifiedDateTime().toString();
+    private static final String VALID_LAST_MODIFIED_DATE_TIME = BENSON.getLastModifiedDateTime().toString();
 
     @Test
     public void toModelType_validPersonDetails_returnsPerson() throws Exception {
@@ -49,7 +50,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_COMPANY, VALID_JOB, VALID_TAGS,
-                        VALID_LASTMODIFIEDDATETIME);
+                        VALID_MARK_STATUS, VALID_LAST_MODIFIED_DATE_TIME);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -57,7 +58,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(
-                null, VALID_PHONE, VALID_EMAIL, VALID_COMPANY, VALID_JOB, VALID_TAGS, VALID_LASTMODIFIEDDATETIME);
+                null, VALID_PHONE, VALID_EMAIL, VALID_COMPANY, VALID_JOB, VALID_TAGS, VALID_MARK_STATUS,
+                VALID_LAST_MODIFIED_DATE_TIME);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -65,8 +67,9 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME,
-                        INVALID_PHONE, VALID_EMAIL, VALID_COMPANY, VALID_JOB, VALID_TAGS, VALID_LASTMODIFIEDDATETIME);
+                new JsonAdaptedPerson(
+                        VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_COMPANY, VALID_JOB, VALID_TAGS,
+                        VALID_MARK_STATUS, VALID_LAST_MODIFIED_DATE_TIME);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -74,7 +77,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(
-                VALID_NAME, null, VALID_EMAIL, VALID_COMPANY, VALID_JOB, VALID_TAGS, VALID_LASTMODIFIEDDATETIME);
+                VALID_NAME, null, VALID_EMAIL, VALID_COMPANY, VALID_JOB, VALID_TAGS, VALID_MARK_STATUS,
+                VALID_LAST_MODIFIED_DATE_TIME);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -83,7 +87,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL,
-                        VALID_COMPANY, VALID_JOB, VALID_TAGS, VALID_LASTMODIFIEDDATETIME);
+                        VALID_COMPANY, VALID_JOB, VALID_TAGS, VALID_MARK_STATUS, VALID_LAST_MODIFIED_DATE_TIME);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -92,7 +96,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(
                 VALID_NAME, VALID_PHONE, null,
-                VALID_COMPANY, VALID_JOB, VALID_TAGS, VALID_LASTMODIFIEDDATETIME);
+                VALID_COMPANY, VALID_JOB, VALID_TAGS, VALID_MARK_STATUS, VALID_LAST_MODIFIED_DATE_TIME);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -101,7 +105,8 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidCompany_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE,
-                        VALID_EMAIL, INVALID_COMPANY, VALID_JOB, VALID_TAGS, VALID_LASTMODIFIEDDATETIME);
+                        VALID_EMAIL, INVALID_COMPANY, VALID_JOB, VALID_TAGS, VALID_MARK_STATUS,
+                        VALID_LAST_MODIFIED_DATE_TIME);
         String expectedMessage = Company.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -109,7 +114,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullCompany_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(
-                VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_JOB, VALID_TAGS, VALID_LASTMODIFIEDDATETIME);
+                VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_JOB, VALID_TAGS, VALID_MARK_STATUS,
+                VALID_LAST_MODIFIED_DATE_TIME);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Company.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -118,7 +124,8 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidJob_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE,
-                        VALID_EMAIL, VALID_COMPANY, INVALID_JOB, VALID_TAGS, VALID_LASTMODIFIEDDATETIME);
+                        VALID_EMAIL, VALID_COMPANY, INVALID_JOB, VALID_TAGS, VALID_MARK_STATUS,
+                        VALID_LAST_MODIFIED_DATE_TIME);
         String expectedMessage = Job.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -126,7 +133,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullJob_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(
-                VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_COMPANY, null, VALID_TAGS, VALID_LASTMODIFIEDDATETIME);
+                VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_COMPANY, null, VALID_TAGS, VALID_MARK_STATUS,
+                VALID_LAST_MODIFIED_DATE_TIME);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Job.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -137,7 +145,8 @@ public class JsonAdaptedPersonTest {
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE,
-                        VALID_EMAIL, VALID_COMPANY, VALID_JOB, invalidTags, VALID_LASTMODIFIEDDATETIME);
+                        VALID_EMAIL, VALID_COMPANY, VALID_JOB, invalidTags, VALID_MARK_STATUS,
+                        VALID_LAST_MODIFIED_DATE_TIME);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 
@@ -145,7 +154,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_nullLastModifiedDateTime_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(
                 VALID_NAME, VALID_PHONE, VALID_EMAIL,
-                VALID_COMPANY, VALID_JOB, VALID_TAGS, null);
+                VALID_COMPANY, VALID_JOB, VALID_TAGS, VALID_MARK_STATUS, null);
         String expectedMessage = String.format(
                 MISSING_FIELD_MESSAGE_FORMAT, LastModifiedDateTime.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
@@ -155,9 +164,9 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidLastModifiedDateTime_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE,
-                        VALID_EMAIL, VALID_COMPANY, VALID_JOB, VALID_TAGS, INVALID_LASTMODIFIEDDATETIME);
+                        VALID_EMAIL, VALID_COMPANY, VALID_JOB, VALID_TAGS, VALID_MARK_STATUS,
+                        INVALID_LAST_MODIFIED_DATE_TIME);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
-
 
 }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -10,6 +10,7 @@ import seedu.address.model.person.Company;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Job;
 import seedu.address.model.person.LastModifiedDateTime;
+import seedu.address.model.person.Mark;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -38,7 +39,7 @@ public class PersonBuilder {
     private Company company;
     private Job job;
     private Set<Tag> tags;
-
+    private Mark markStatus;
     private LastModifiedDateTime lastModifiedDateTime;
 
     /**
@@ -127,4 +128,11 @@ public class PersonBuilder {
         return new Person(name, phone, email, company, job, tags, lastModifiedDateTime);
     }
 
+    /**
+     * Sets the {@code markStatus} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withMarkStatus(boolean b) {
+        this.markStatus = new Mark(b);
+        return this;
+    }
 }


### PR DESCRIPTION
Allows users to mark and unmark contacts of interest.

Marked users (after executing `mark`) will have a solid star (★) indicated in their person card, ☆ otherwise.

Passes all test cases. 