### PR TITLE
Add personfield interface

### DIFF
--- a/src/main/java/connexion/model/person/Company.java
+++ b/src/main/java/connexion/model/person/Company.java
@@ -7,7 +7,7 @@ import static java.util.Objects.requireNonNull;
  * Represents a Person's company in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidCompany(String)}
  */
-public class Company {
+public class Company implements PersonListDetailField<String> {
 
     public static final String MESSAGE_CONSTRAINTS = "Company can take any values, and it should not be blank";
 
@@ -17,7 +17,7 @@ public class Company {
      */
     public static final String VALIDATION_REGEX = "[^\\s].*";
 
-    public final String value;
+    private final String value;
 
     /**
      * Constructs an {@code company}.
@@ -62,4 +62,18 @@ public class Company {
         return value.hashCode();
     }
 
+    @Override
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String getListString() {
+        return value;
+    }
+
+    @Override
+    public String getDetailString() {
+        return value;
+    }
 }

--- a/src/main/java/connexion/model/person/CompanyContainsKeywordsPredicate.java
+++ b/src/main/java/connexion/model/person/CompanyContainsKeywordsPredicate.java
@@ -19,7 +19,7 @@ public class CompanyContainsKeywordsPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getCompany().value, keyword));
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getCompany().getValue(), keyword));
     }
 
     @Override

--- a/src/main/java/connexion/model/person/Email.java
+++ b/src/main/java/connexion/model/person/Email.java
@@ -7,7 +7,7 @@ import static java.util.Objects.requireNonNull;
  * Represents a Person's email in Connexion.
  * Guarantees: immutable; is valid as declared in {@link #isValidEmail(String)}
  */
-public class Email {
+public class Email implements PersonDetailField<String>{
 
     private static final String SPECIAL_CHARACTERS = "+_.-";
     public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
@@ -31,7 +31,7 @@ public class Email {
     private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
     public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
 
-    public final String value;
+    private final String value;
 
     /**
      * Constructs an {@code Email}.
@@ -74,6 +74,16 @@ public class Email {
     @Override
     public int hashCode() {
         return value.hashCode();
+    }
+
+    @Override
+    public String getDetailString() {
+        return value;
+    }
+
+    @Override
+    public String getValue() {
+        return value;
     }
 
 }

--- a/src/main/java/connexion/model/person/Email.java
+++ b/src/main/java/connexion/model/person/Email.java
@@ -7,7 +7,7 @@ import static java.util.Objects.requireNonNull;
  * Represents a Person's email in Connexion.
  * Guarantees: immutable; is valid as declared in {@link #isValidEmail(String)}
  */
-public class Email implements PersonDetailField<String>{
+public class Email implements PersonDetailField<String> {
 
     private static final String SPECIAL_CHARACTERS = "+_.-";
     public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "

--- a/src/main/java/connexion/model/person/EmailContainsKeywordsPredicate.java
+++ b/src/main/java/connexion/model/person/EmailContainsKeywordsPredicate.java
@@ -19,7 +19,7 @@ public class EmailContainsKeywordsPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getEmail().value, keyword));
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getEmail().getValue(), keyword));
     }
 
     @Override

--- a/src/main/java/connexion/model/person/Job.java
+++ b/src/main/java/connexion/model/person/Job.java
@@ -7,7 +7,7 @@ import static java.util.Objects.requireNonNull;
  * Represents a Person's job in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidJob(String)}
  */
-public class Job {
+public class Job implements PersonListDetailField<String> {
 
     public static final String MESSAGE_CONSTRAINTS = "Job can take any values, and it should not be blank";
 
@@ -17,7 +17,7 @@ public class Job {
      */
     public static final String VALIDATION_REGEX = "[^\\s].*";
 
-    public final String value;
+    private final String value;
 
     /**
      * Constructs an {@code Job}.
@@ -62,4 +62,18 @@ public class Job {
         return value.hashCode();
     }
 
+    @Override
+    public String getDetailString() {
+        return value;
+    }
+
+    @Override
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String getListString() {
+        return value;
+    }
 }

--- a/src/main/java/connexion/model/person/JobContainsKeywordsPredicate.java
+++ b/src/main/java/connexion/model/person/JobContainsKeywordsPredicate.java
@@ -19,7 +19,7 @@ public class JobContainsKeywordsPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getJob().value, keyword));
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getJob().getValue(), keyword));
     }
 
     @Override

--- a/src/main/java/connexion/model/person/LastModifiedDateTime.java
+++ b/src/main/java/connexion/model/person/LastModifiedDateTime.java
@@ -16,7 +16,7 @@ import java.util.Locale;
  * Represents when a Person was last modified in the address book.
  * Guarantees: immutable; is valid as declared in LocalDateTime java API
  */
-public class LastModifiedDateTime {
+public class LastModifiedDateTime implements PersonDetailField<LocalDateTime>{
 
     public static final String MESSAGE_CONSTRAINTS =
             "Last modified should consist of a DateTime Object or the date as a string that is correct"
@@ -111,5 +111,15 @@ public class LastModifiedDateTime {
     @Override
     public int hashCode() {
         return lastModified.hashCode();
+    }
+
+    @Override
+    public String getDetailString() {
+        return lastModified.format(LASTMODIFIED_FORMATTER);
+    }
+
+    @Override
+    public LocalDateTime getValue() {
+        return lastModified;
     }
 }

--- a/src/main/java/connexion/model/person/LastModifiedDateTime.java
+++ b/src/main/java/connexion/model/person/LastModifiedDateTime.java
@@ -16,7 +16,7 @@ import java.util.Locale;
  * Represents when a Person was last modified in the address book.
  * Guarantees: immutable; is valid as declared in LocalDateTime java API
  */
-public class LastModifiedDateTime implements PersonDetailField<LocalDateTime>{
+public class LastModifiedDateTime implements PersonDetailField<LocalDateTime> {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Last modified should consist of a DateTime Object or the date as a string that is correct"

--- a/src/main/java/connexion/model/person/Mark.java
+++ b/src/main/java/connexion/model/person/Mark.java
@@ -6,15 +6,16 @@ import static java.util.Objects.requireNonNull;
  * Represents the mark status in the address book.
  * Guarantees: mutable.
  */
-public class Mark implements PersonListDetailField<Boolean>{
+public class Mark implements PersonListDetailField<Boolean> {
     public static final String MESSAGE_CONSTRAINTS =
             "Mark Status can only be true or false!";
 
-    private boolean markStatus;
-
+    private static final String UNMARKED_STAR = "☆";
     private static final String MARKED_STAR = "★";
 
-    private static final String UNMARKED_STAR = "☆";
+    private boolean markStatus;
+
+
 
     /**
      * Constructs Mark Object.

--- a/src/main/java/connexion/model/person/Mark.java
+++ b/src/main/java/connexion/model/person/Mark.java
@@ -6,11 +6,15 @@ import static java.util.Objects.requireNonNull;
  * Represents the mark status in the address book.
  * Guarantees: mutable.
  */
-public class Mark {
+public class Mark implements PersonListDetailField<Boolean>{
     public static final String MESSAGE_CONSTRAINTS =
             "Mark Status can only be true or false!";
 
     private boolean markStatus;
+
+    private static final String MARKED_STAR = "★";
+
+    private static final String UNMARKED_STAR = "☆";
 
     /**
      * Constructs Mark Object.
@@ -46,11 +50,7 @@ public class Mark {
 
     @Override
     public String toString() {
-        if (markStatus == true) {
-            return "\u2605"; //★
-        } else {
-            return "\u2606"; //☆
-        }
+        return (markStatus ? MARKED_STAR : UNMARKED_STAR);
     }
 
     @Override
@@ -58,4 +58,18 @@ public class Mark {
         return String.valueOf(markStatus).hashCode();
     }
 
+    @Override
+    public String getDetailString() {
+        return (markStatus ? MARKED_STAR : UNMARKED_STAR);
+    }
+
+    @Override
+    public Boolean getValue() {
+        return markStatus;
+    }
+
+    @Override
+    public String getListString() {
+        return (markStatus ? MARKED_STAR : UNMARKED_STAR);
+    }
 }

--- a/src/main/java/connexion/model/person/Name.java
+++ b/src/main/java/connexion/model/person/Name.java
@@ -7,7 +7,7 @@ import static java.util.Objects.requireNonNull;
  * Represents a Person's name in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
  */
-public class Name {
+public class Name implements PersonListDetailField<String> {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Names should only contain alphanumeric characters and spaces, and it should not be blank";
@@ -18,7 +18,7 @@ public class Name {
      */
     public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
 
-    public final String fullName;
+    private final String fullName;
 
     /**
      * Constructs a {@code Name}.
@@ -64,4 +64,18 @@ public class Name {
         return fullName.hashCode();
     }
 
+    @Override
+    public String getDetailString() {
+        return fullName;
+    }
+
+    @Override
+    public String getValue() {
+        return fullName;
+    }
+
+    @Override
+    public String getListString() {
+        return fullName;
+    }
 }

--- a/src/main/java/connexion/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/connexion/model/person/NameContainsKeywordsPredicate.java
@@ -19,7 +19,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().getValue(), keyword));
     }
 
     @Override

--- a/src/main/java/connexion/model/person/PersonDetailField.java
+++ b/src/main/java/connexion/model/person/PersonDetailField.java
@@ -1,6 +1,17 @@
 package connexion.model.person;
 
+
+/**
+ * API for fields in general that are associated with Person, with a defined method for retrieving the string
+ * representation for view in a more verbose context.
+ * For some fields, they may have only representations in a more verbose context as they are meant to only be seen
+ * in a more verbose context.
+ * @param <T> the datatype this field wraps around
+ */
 public interface PersonDetailField<T> extends PersonField<T>{
 
+    /**
+     * Returns the user-facing string representation of this field in a detail view.
+     */
     public String getDetailString();
 }

--- a/src/main/java/connexion/model/person/PersonDetailField.java
+++ b/src/main/java/connexion/model/person/PersonDetailField.java
@@ -8,7 +8,7 @@ package connexion.model.person;
  * in a more verbose context.
  * @param <T> the datatype this field wraps around
  */
-public interface PersonDetailField<T> extends PersonField<T>{
+public interface PersonDetailField<T> extends PersonField<T> {
 
     /**
      * Returns the user-facing string representation of this field in a detail view.

--- a/src/main/java/connexion/model/person/PersonDetailField.java
+++ b/src/main/java/connexion/model/person/PersonDetailField.java
@@ -1,0 +1,6 @@
+package connexion.model.person;
+
+public interface PersonDetailField<T> extends PersonField<T>{
+
+    public String getDetailString();
+}

--- a/src/main/java/connexion/model/person/PersonField.java
+++ b/src/main/java/connexion/model/person/PersonField.java
@@ -1,6 +1,14 @@
 package connexion.model.person;
 
+/**
+ * API for fields in general that are associated with Person, but with no defined method to access user-facing
+ * string representations
+ * @param <T> the datatype this field wraps around
+ */
 public interface PersonField<T> {
 
+    /**
+     * Returns the value within this field.
+     */
     public T getValue();
 }

--- a/src/main/java/connexion/model/person/PersonField.java
+++ b/src/main/java/connexion/model/person/PersonField.java
@@ -1,0 +1,6 @@
+package connexion.model.person;
+
+public interface PersonField<T> {
+
+    public T getValue();
+}

--- a/src/main/java/connexion/model/person/PersonListDetailField.java
+++ b/src/main/java/connexion/model/person/PersonListDetailField.java
@@ -6,5 +6,5 @@ package connexion.model.person;
  * representation for view in both an at-a-glance and a more verbose context.
  * @param <T> the datatype this field wraps around
  */
-public interface PersonListDetailField<T> extends PersonDetailField<T>, PersonListField<T>{
+public interface PersonListDetailField<T> extends PersonDetailField<T>, PersonListField<T> {
 }

--- a/src/main/java/connexion/model/person/PersonListDetailField.java
+++ b/src/main/java/connexion/model/person/PersonListDetailField.java
@@ -1,0 +1,4 @@
+package connexion.model.person;
+
+public interface PersonListDetailField<T> extends PersonDetailField<T>, PersonListField<T>{
+}

--- a/src/main/java/connexion/model/person/PersonListDetailField.java
+++ b/src/main/java/connexion/model/person/PersonListDetailField.java
@@ -1,4 +1,10 @@
 package connexion.model.person;
 
+
+/**
+ * API for fields in general that are associated with Person, with a defined method for retrieving the string
+ * representation for view in both an at-a-glance and a more verbose context.
+ * @param <T> the datatype this field wraps around
+ */
 public interface PersonListDetailField<T> extends PersonDetailField<T>, PersonListField<T>{
 }

--- a/src/main/java/connexion/model/person/PersonListField.java
+++ b/src/main/java/connexion/model/person/PersonListField.java
@@ -5,7 +5,7 @@ package connexion.model.person;
  * representation for view in an at-a-glance context.
  * @param <T> the datatype this field wraps around
  */
-public interface PersonListField<T> extends PersonField<T>{
+public interface PersonListField<T> extends PersonField<T> {
 
     /**
      * Returns the user-facing string representation of this field in an at-a-glance view.

--- a/src/main/java/connexion/model/person/PersonListField.java
+++ b/src/main/java/connexion/model/person/PersonListField.java
@@ -1,6 +1,14 @@
 package connexion.model.person;
 
+/**
+ * API for fields in general that are associated with Person, with a defined method for retrieving the string
+ * representation for view in an at-a-glance context.
+ * @param <T> the datatype this field wraps around
+ */
 public interface PersonListField<T> extends PersonField<T>{
 
+    /**
+     * Returns the user-facing string representation of this field in an at-a-glance view.
+     */
     public String getListString();
 }

--- a/src/main/java/connexion/model/person/PersonListField.java
+++ b/src/main/java/connexion/model/person/PersonListField.java
@@ -1,0 +1,6 @@
+package connexion.model.person;
+
+public interface PersonListField<T> extends PersonField<T>{
+
+    public String getListString();
+}

--- a/src/main/java/connexion/model/person/Phone.java
+++ b/src/main/java/connexion/model/person/Phone.java
@@ -7,7 +7,7 @@ import static java.util.Objects.requireNonNull;
  * Represents a Person's phone number in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidPhone(String)}
  */
-public class Phone implements PersonDetailField<String>{
+public class Phone implements PersonDetailField<String> {
 
 
     public static final String MESSAGE_CONSTRAINTS =

--- a/src/main/java/connexion/model/person/Phone.java
+++ b/src/main/java/connexion/model/person/Phone.java
@@ -7,13 +7,13 @@ import static java.util.Objects.requireNonNull;
  * Represents a Person's phone number in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidPhone(String)}
  */
-public class Phone {
+public class Phone implements PersonDetailField<String>{
 
 
     public static final String MESSAGE_CONSTRAINTS =
             "Phone numbers should only contain numbers, and it should be at least 3 digits long";
     public static final String VALIDATION_REGEX = "\\d{3,}";
-    public final String value;
+    private final String value;
 
     /**
      * Constructs a {@code Phone}.
@@ -58,4 +58,13 @@ public class Phone {
         return value.hashCode();
     }
 
+    @Override
+    public String getDetailString() {
+        return value;
+    }
+
+    @Override
+    public String getValue() {
+        return value;
+    }
 }

--- a/src/main/java/connexion/model/person/PhoneContainsKeywordsPredicate.java
+++ b/src/main/java/connexion/model/person/PhoneContainsKeywordsPredicate.java
@@ -19,7 +19,7 @@ public class PhoneContainsKeywordsPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getPhone().value, keyword));
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getPhone().getValue(), keyword));
     }
 
     @Override

--- a/src/main/java/connexion/model/tag/Tag.java
+++ b/src/main/java/connexion/model/tag/Tag.java
@@ -1,5 +1,7 @@
 package connexion.model.tag;
 
+import connexion.model.person.PersonListDetailField;
+
 import static connexion.commons.util.AppUtil.checkArgument;
 import static java.util.Objects.requireNonNull;
 
@@ -7,12 +9,12 @@ import static java.util.Objects.requireNonNull;
  * Represents a Tag in the address book.
  * Guarantees: immutable; name is valid as declared in {@link #isValidTagName(String)}
  */
-public class Tag {
+public class Tag implements PersonListDetailField<String> {
 
     public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
     public static final String VALIDATION_REGEX = "\\p{Alnum}+";
 
-    public final String tagName;
+    private final String tagName;
 
     /**
      * Constructs a {@code Tag}.
@@ -59,4 +61,18 @@ public class Tag {
         return '[' + tagName + ']';
     }
 
+    @Override
+    public String getDetailString() {
+        return tagName;
+    }
+
+    @Override
+    public String getValue() {
+        return tagName;
+    }
+
+    @Override
+    public String getListString() {
+        return tagName;
+    }
 }

--- a/src/main/java/connexion/model/tag/Tag.java
+++ b/src/main/java/connexion/model/tag/Tag.java
@@ -1,9 +1,9 @@
 package connexion.model.tag;
 
-import connexion.model.person.PersonListDetailField;
-
 import static connexion.commons.util.AppUtil.checkArgument;
 import static java.util.Objects.requireNonNull;
+
+import connexion.model.person.PersonListDetailField;
 
 /**
  * Represents a Tag in the address book.

--- a/src/main/java/connexion/model/tag/TagContainsKeywordsPredicate.java
+++ b/src/main/java/connexion/model/tag/TagContainsKeywordsPredicate.java
@@ -22,7 +22,7 @@ public class TagContainsKeywordsPredicate implements Predicate<Person> {
         return keywords.stream()
                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(
                         person.getTags().stream()
-                                .reduce("", (str, tag) -> str + " " + tag.tagName, (str1, str2) -> str1 + " " + str2),
+                                .reduce("", (str, tag) -> str + " " + tag.getValue(), (str1, str2) -> str1 + " " + str2),
                         keyword));
     }
 

--- a/src/main/java/connexion/model/tag/TagContainsKeywordsPredicate.java
+++ b/src/main/java/connexion/model/tag/TagContainsKeywordsPredicate.java
@@ -21,9 +21,13 @@ public class TagContainsKeywordsPredicate implements Predicate<Person> {
     public boolean test(Person person) {
         return keywords.stream()
                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(
-                        person.getTags().stream()
-                                .reduce("", (str, tag) -> str + " " + tag.getValue(), (str1, str2) -> str1 + " " + str2),
+                        person.getTags()
+                                .stream().reduce(
+                                        "", (// I'm so sorry for this but checkstyle insists on this
+                                                str, tag) -> str + " " + tag.getValue(), (
+                                                        str1, str2) -> str1 + " " + str2),
                         keyword));
+        //Above line concatenates all tags together with a space in between each one
     }
 
     @Override

--- a/src/main/java/connexion/storage/JsonAdaptedPerson.java
+++ b/src/main/java/connexion/storage/JsonAdaptedPerson.java
@@ -61,11 +61,11 @@ class JsonAdaptedPerson {
      * Converts a given {@code Person} into this class for Jackson use.
      */
     public JsonAdaptedPerson(Person source) {
-        name = source.getName().toString();
-        phone = source.getPhone().toString();
-        email = source.getEmail().toString();
-        company = source.getCompany().toString();
-        job = source.getJob().toString();
+        name = source.getName().getValue();
+        phone = source.getPhone().getValue();
+        email = source.getEmail().getValue();
+        company = source.getCompany().getValue();
+        job = source.getJob().getValue();
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));

--- a/src/main/java/connexion/storage/JsonAdaptedPerson.java
+++ b/src/main/java/connexion/storage/JsonAdaptedPerson.java
@@ -61,11 +61,11 @@ class JsonAdaptedPerson {
      * Converts a given {@code Person} into this class for Jackson use.
      */
     public JsonAdaptedPerson(Person source) {
-        name = source.getName().fullName;
-        phone = source.getPhone().value;
-        email = source.getEmail().value;
-        company = source.getCompany().value;
-        job = source.getJob().value;
+        name = source.getName().toString();
+        phone = source.getPhone().toString();
+        email = source.getEmail().toString();
+        company = source.getCompany().toString();
+        job = source.getJob().toString();
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));

--- a/src/main/java/connexion/storage/JsonAdaptedTag.java
+++ b/src/main/java/connexion/storage/JsonAdaptedTag.java
@@ -25,7 +25,7 @@ class JsonAdaptedTag {
      * Converts a given {@code Tag} into this class for Jackson use.
      */
     public JsonAdaptedTag(Tag source) {
-        tagName = source.tagName;
+        tagName = source.getValue();
     }
 
     @JsonValue

--- a/src/main/java/connexion/ui/PersonCard.java
+++ b/src/main/java/connexion/ui/PersonCard.java
@@ -3,6 +3,7 @@ package connexion.ui;
 import java.util.Comparator;
 
 import connexion.model.person.Person;
+import connexion.model.tag.Tag;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
@@ -54,15 +55,15 @@ public class PersonCard extends UiPart<Region> {
         super(FXML);
         this.person = person;
         id.setText(displayedIndex + ". ");
-        name.setText(person.getName().fullName);
-        phone.setText(person.getPhone().value);
-        company.setText(person.getCompany().value);
-        job.setText(person.getJob().value);
-        email.setText(person.getEmail().value);
+        name.setText(person.getName().getListString());
+        phone.setText(person.getPhone().toString());
+        company.setText(person.getCompany().getListString());
+        job.setText(person.getJob().getListString());
+        email.setText(person.getEmail().toString());
         markStatus.setText(person.getMarkStatus().toString());
         person.getTags().stream()
-                .sorted(Comparator.comparing(tag -> tag.tagName))
-                .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+                .sorted(Comparator.comparing(Tag::getValue))
+                .forEach(tag -> tags.getChildren().add(new Label(tag.getListString())));
         lastModifiedDateTime.setText(
                 String.format("Last modified : %s", person.getLastModifiedDateTime().toString()));
 

--- a/src/test/java/connexion/logic/commands/CommandTestUtil.java
+++ b/src/test/java/connexion/logic/commands/CommandTestUtil.java
@@ -137,7 +137,7 @@ public class CommandTestUtil {
         assertTrue(targetIndex.getZeroBased() < model.getFilteredPersonList().size());
 
         Person person = model.getFilteredPersonList().get(targetIndex.getZeroBased());
-        final String[] splitName = person.getName().fullName.split("\\s+");
+        final String[] splitName = person.getName().getValue().split("\\s+");
         model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
 
         assertEquals(1, model.getFilteredPersonList().size());

--- a/src/test/java/connexion/model/ModelManagerTest.java
+++ b/src/test/java/connexion/model/ModelManagerTest.java
@@ -117,7 +117,7 @@ public class ModelManagerTest {
         assertFalse(modelManager.equals(new ModelManager(differentAddressBook, userPrefs)));
 
         // different filteredList -> returns false
-        String[] keywords = ALICE.getName().fullName.split("\\s+");
+        String[] keywords = ALICE.getName().getValue().split("\\s+");
         modelManager.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
         assertFalse(modelManager.equals(new ModelManager(addressBook, userPrefs)));
 

--- a/src/test/java/connexion/model/person/CompanyTest.java
+++ b/src/test/java/connexion/model/person/CompanyTest.java
@@ -1,7 +1,9 @@
 package connexion.model.person;
 
 import static connexion.testutil.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -18,6 +20,8 @@ public class CompanyTest {
         String invalidCompany = "";
         assertThrows(IllegalArgumentException.class, () -> new Company(invalidCompany));
     }
+    
+
 
     @Test
     public void isValidCompany() {
@@ -52,5 +56,26 @@ public class CompanyTest {
 
         // different values -> returns false
         assertFalse(company.equals(new Company("Other Valid Company")));
+    }
+
+    @Test
+    void getDetailString_equals_input() {
+        Company company = new Company("Valid Company");
+        assertEquals(company.getDetailString(),"Valid Company");
+        assertNotEquals(company.getDetailString(), "Nonsense"); //to show it's actually matching the string
+    }
+
+    @Test
+    void getValue_equals_input() {
+        Company company = new Company("Valid Company");
+        assertEquals(company.getValue(),"Valid Company");
+        assertNotEquals(company.getValue(), "Nonsense"); //to show it's actually matching the string
+    }
+
+    @Test
+    void getListString_equals_input() {
+        Company company = new Company("Valid Company");
+        assertEquals(company.getValue(),"Valid Company");
+        assertNotEquals(company.getValue(), "Nonsense"); //to show it's actually matching the string
     }
 }

--- a/src/test/java/connexion/model/person/CompanyTest.java
+++ b/src/test/java/connexion/model/person/CompanyTest.java
@@ -20,8 +20,6 @@ public class CompanyTest {
         String invalidCompany = "";
         assertThrows(IllegalArgumentException.class, () -> new Company(invalidCompany));
     }
-    
-
 
     @Test
     public void isValidCompany() {
@@ -61,21 +59,21 @@ public class CompanyTest {
     @Test
     void getDetailString_equals_input() {
         Company company = new Company("Valid Company");
-        assertEquals(company.getDetailString(),"Valid Company");
+        assertEquals(company.getDetailString(), "Valid Company");
         assertNotEquals(company.getDetailString(), "Nonsense"); //to show it's actually matching the string
     }
 
     @Test
     void getValue_equals_input() {
         Company company = new Company("Valid Company");
-        assertEquals(company.getValue(),"Valid Company");
+        assertEquals(company.getValue(), "Valid Company");
         assertNotEquals(company.getValue(), "Nonsense"); //to show it's actually matching the string
     }
 
     @Test
     void getListString_equals_input() {
         Company company = new Company("Valid Company");
-        assertEquals(company.getValue(),"Valid Company");
+        assertEquals(company.getValue(), "Valid Company");
         assertNotEquals(company.getValue(), "Nonsense"); //to show it's actually matching the string
     }
 }

--- a/src/test/java/connexion/model/person/CompanyTest.java
+++ b/src/test/java/connexion/model/person/CompanyTest.java
@@ -73,7 +73,7 @@ public class CompanyTest {
     @Test
     void getListString_equals_input() {
         Company company = new Company("Valid Company");
-        assertEquals(company.getValue(), "Valid Company");
-        assertNotEquals(company.getValue(), "Nonsense"); //to show it's actually matching the string
+        assertEquals(company.getListString(), "Valid Company");
+        assertNotEquals(company.getListString(), "Nonsense"); //to show it's actually matching the string
     }
 }

--- a/src/test/java/connexion/model/person/EmailTest.java
+++ b/src/test/java/connexion/model/person/EmailTest.java
@@ -1,7 +1,9 @@
 package connexion.model.person;
 
 import static connexion.testutil.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -84,5 +86,18 @@ public class EmailTest {
 
         // different values -> returns false
         assertFalse(email.equals(new Email("other.valid@email")));
+    }
+
+    @Test
+    void getValue_equals_input() {
+        Email email = new Email("valid@email");
+        assertEquals(email.getValue(),"valid@email");
+        assertNotEquals(email.getValue(), "nonsense@nonsense"); //to show it's actually matching the string
+    }
+    @Test
+    void getDetailString_equals_input() {
+        Email email = new Email("valid@email");
+        assertEquals(email.getDetailString(),"valid@email");
+        assertNotEquals(email.getDetailString(), "nonsense@nonsense"); //to show it's actually matching the string
     }
 }

--- a/src/test/java/connexion/model/person/EmailTest.java
+++ b/src/test/java/connexion/model/person/EmailTest.java
@@ -91,13 +91,13 @@ public class EmailTest {
     @Test
     void getValue_equals_input() {
         Email email = new Email("valid@email");
-        assertEquals(email.getValue(),"valid@email");
+        assertEquals(email.getValue(), "valid@email");
         assertNotEquals(email.getValue(), "nonsense@nonsense"); //to show it's actually matching the string
     }
     @Test
     void getDetailString_equals_input() {
         Email email = new Email("valid@email");
-        assertEquals(email.getDetailString(),"valid@email");
+        assertEquals(email.getDetailString(), "valid@email");
         assertNotEquals(email.getDetailString(), "nonsense@nonsense"); //to show it's actually matching the string
     }
 }

--- a/src/test/java/connexion/model/person/JobTest.java
+++ b/src/test/java/connexion/model/person/JobTest.java
@@ -1,7 +1,9 @@
 package connexion.model.person;
 
 import static connexion.testutil.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -52,5 +54,26 @@ public class JobTest {
 
         // different values -> returns false
         assertFalse(job.equals(new Job("Other Valid Job")));
+    }
+
+    @Test
+    void getDetailString_equals_input() {
+        Job job = new Job("Valid Job");
+        assertEquals(job.getDetailString(),"Valid Job");
+        assertNotEquals(job.getDetailString(), "Nonsense"); //to show it's actually matching the string
+    }
+
+    @Test
+    void getValue_equals_input() {
+        Job job = new Job("Valid Job");
+        assertEquals(job.getValue(),"Valid Job");
+        assertNotEquals(job.getValue(), "Nonsense"); //to show it's actually matching the string
+    }
+
+    @Test
+    void getListString_equals_input() {
+        Job job = new Job("Valid Job");
+        assertEquals(job.getListString(),"Valid Job");
+        assertNotEquals(job.getListString(), "Nonsense"); //to show it's actually matching the string
     }
 }

--- a/src/test/java/connexion/model/person/JobTest.java
+++ b/src/test/java/connexion/model/person/JobTest.java
@@ -59,21 +59,21 @@ public class JobTest {
     @Test
     void getDetailString_equals_input() {
         Job job = new Job("Valid Job");
-        assertEquals(job.getDetailString(),"Valid Job");
+        assertEquals(job.getDetailString(), "Valid Job");
         assertNotEquals(job.getDetailString(), "Nonsense"); //to show it's actually matching the string
     }
 
     @Test
     void getValue_equals_input() {
         Job job = new Job("Valid Job");
-        assertEquals(job.getValue(),"Valid Job");
+        assertEquals(job.getValue(), "Valid Job");
         assertNotEquals(job.getValue(), "Nonsense"); //to show it's actually matching the string
     }
 
     @Test
     void getListString_equals_input() {
         Job job = new Job("Valid Job");
-        assertEquals(job.getListString(),"Valid Job");
+        assertEquals(job.getListString(), "Valid Job");
         assertNotEquals(job.getListString(), "Nonsense"); //to show it's actually matching the string
     }
 }

--- a/src/test/java/connexion/model/person/LastModifiedDateTimeTest.java
+++ b/src/test/java/connexion/model/person/LastModifiedDateTimeTest.java
@@ -128,11 +128,6 @@ class LastModifiedDateTimeTest {
         assertNotEquals(new LastModifiedDateTime(OTHER_TEST_TIME).getValue(),
                 OTHER_TEST_TIME);
 
-        assertEquals(new LastModifiedDateTime(DEFAULT_TEST_TIME).getValue(),
-                new LastModifiedDateTime(DEFAULT_TEST_TIME).getValue());
-        assertNotEquals(new LastModifiedDateTime(DEFAULT_TEST_TIME).getValue(),
-                new LastModifiedDateTime(OTHER_TEST_TIME).getValue());
-
         // Special case where higher precision past seconds is already zero
         // So truncating doesn't do anything
         assertEquals(new LastModifiedDateTime(LocalDateTime.MIN).getValue(),

--- a/src/test/java/connexion/model/person/LastModifiedDateTimeTest.java
+++ b/src/test/java/connexion/model/person/LastModifiedDateTimeTest.java
@@ -2,6 +2,7 @@ package connexion.model.person;
 
 import static connexion.testutil.Assert.assertThrows;
 import static connexion.testutil.ClockUtil.DEFAULT_TEST_TIME;
+import static connexion.testutil.ClockUtil.OTHER_TEST_TIME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -9,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 
 import org.junit.jupiter.api.Test;
 
@@ -99,4 +101,44 @@ class LastModifiedDateTimeTest {
     }
 
 
+    @Test
+    void getDetailString() {
+        assertEquals(new LastModifiedDateTime(DEFAULT_TEST_TIME).getDetailString(),
+                DEFAULT_TEST_TIME.format(LastModifiedDateTime.LASTMODIFIED_FORMATTER));
+        assertEquals(new LastModifiedDateTime(LocalDateTime.MAX).getDetailString(),
+                LocalDateTime.MAX.format(LastModifiedDateTime.LASTMODIFIED_FORMATTER));
+        assertEquals(new LastModifiedDateTime(LocalDateTime.MIN).getDetailString(),
+                LocalDateTime.MIN.format(LastModifiedDateTime.LASTMODIFIED_FORMATTER));
+    }
+
+    @Test
+    void getValue() {
+        assertEquals(new LastModifiedDateTime(DEFAULT_TEST_TIME).getValue(),
+                DEFAULT_TEST_TIME.truncatedTo(ChronoUnit.SECONDS));
+        assertNotEquals(new LastModifiedDateTime(DEFAULT_TEST_TIME).getValue(),
+                DEFAULT_TEST_TIME);
+        // Note that LastModifiedDateTime truncates to seconds, so higher precision should generally not be equal
+        // Doesn't apply to cases where is zero already, naturally!
+        assertEquals(new LastModifiedDateTime(LocalDateTime.MAX).getValue(),
+                LocalDateTime.MAX.truncatedTo(ChronoUnit.SECONDS));
+        assertNotEquals(new LastModifiedDateTime(LocalDateTime.MAX).getValue(),
+                LocalDateTime.MAX);
+        assertEquals(new LastModifiedDateTime(OTHER_TEST_TIME).getValue(),
+               OTHER_TEST_TIME.truncatedTo(ChronoUnit.SECONDS));
+        assertNotEquals(new LastModifiedDateTime(OTHER_TEST_TIME).getValue(),
+                OTHER_TEST_TIME);
+
+        assertEquals(new LastModifiedDateTime(DEFAULT_TEST_TIME).getValue(),
+                new LastModifiedDateTime(DEFAULT_TEST_TIME).getValue());
+        assertNotEquals(new LastModifiedDateTime(DEFAULT_TEST_TIME).getValue(),
+                new LastModifiedDateTime(OTHER_TEST_TIME).getValue());
+
+        // Special case where higher precision past seconds is already zero
+        // So truncating doesn't do anything
+        assertEquals(new LastModifiedDateTime(LocalDateTime.MIN).getValue(),
+                LocalDateTime.MIN.truncatedTo(ChronoUnit.SECONDS));
+        assertEquals(new LastModifiedDateTime(LocalDateTime.MIN).getValue(),
+                LocalDateTime.MIN);
+
+    }
 }

--- a/src/test/java/connexion/model/person/MarkTest.java
+++ b/src/test/java/connexion/model/person/MarkTest.java
@@ -45,4 +45,37 @@ public class MarkTest {
         assertEquals("\u2606", unmarkedMark.toString());
     }
 
+    @Test
+    void getDetailString_markedStatus() {
+        Mark markedMark = new Mark(true);
+        assertEquals("\u2605", markedMark.getDetailString());
+    }
+    @Test
+    void getDetailString_unmarkedStatus() {
+        Mark unmarkedMark = new Mark(false);
+        assertEquals("\u2606", unmarkedMark.getDetailString());
+    }
+
+    @Test
+    void getValue_markedStatus() {
+        Mark markedMark = new Mark(true);
+        assertEquals(true, markedMark.getValue());
+    }
+    @Test
+    void getValue_unmarkedStatus() {
+        Mark unmarkedMark = new Mark(false);
+        assertEquals(false, unmarkedMark.getValue());
+    }
+
+
+    @Test
+    void getListString_markedStatus() {
+        Mark markedMark = new Mark(true);
+        assertEquals("\u2605", markedMark.getListString());
+    }
+    @Test
+    void getListString_unmarkedStatus() {
+        Mark unmarkedMark = new Mark(false);
+        assertEquals("\u2606", unmarkedMark.getListString());
+    }
 }

--- a/src/test/java/connexion/model/person/NameTest.java
+++ b/src/test/java/connexion/model/person/NameTest.java
@@ -1,7 +1,9 @@
 package connexion.model.person;
 
 import static connexion.testutil.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -56,5 +58,26 @@ public class NameTest {
 
         // different values -> returns false
         assertFalse(name.equals(new Name("Other Valid Name")));
+    }
+
+    @Test
+    void getDetailString_equals_input() {
+        Name name = new Name("Valid Name");
+        assertEquals(name.getDetailString(),"Valid Name");
+        assertNotEquals(name.getDetailString(), "Nonsense"); //to show it's actually matching the string
+    }
+
+    @Test
+    void getValue_equals_input() {
+        Name name = new Name("Valid Name");
+        assertEquals(name.getValue(),"Valid Name");
+        assertNotEquals(name.getValue(), "Nonsense"); //to show it's actually matching the string
+    }
+
+    @Test
+    void getListString_equals_input() {
+        Name name = new Name("Valid Name");
+        assertEquals(name.getListString(),"Valid Name");
+        assertNotEquals(name.getListString(), "Nonsense"); //to show it's actually matching the string
     }
 }

--- a/src/test/java/connexion/model/person/NameTest.java
+++ b/src/test/java/connexion/model/person/NameTest.java
@@ -63,21 +63,21 @@ public class NameTest {
     @Test
     void getDetailString_equals_input() {
         Name name = new Name("Valid Name");
-        assertEquals(name.getDetailString(),"Valid Name");
+        assertEquals(name.getDetailString(), "Valid Name");
         assertNotEquals(name.getDetailString(), "Nonsense"); //to show it's actually matching the string
     }
 
     @Test
     void getValue_equals_input() {
         Name name = new Name("Valid Name");
-        assertEquals(name.getValue(),"Valid Name");
+        assertEquals(name.getValue(), "Valid Name");
         assertNotEquals(name.getValue(), "Nonsense"); //to show it's actually matching the string
     }
 
     @Test
     void getListString_equals_input() {
         Name name = new Name("Valid Name");
-        assertEquals(name.getListString(),"Valid Name");
+        assertEquals(name.getListString(), "Valid Name");
         assertNotEquals(name.getListString(), "Nonsense"); //to show it's actually matching the string
     }
 }

--- a/src/test/java/connexion/model/person/PhoneTest.java
+++ b/src/test/java/connexion/model/person/PhoneTest.java
@@ -63,14 +63,14 @@ public class PhoneTest {
     @Test
     void getDetailString_equals_input() {
         Phone phone = new Phone("999");
-        assertEquals(phone.getDetailString(),"999");
+        assertEquals(phone.getDetailString(), "999");
         assertNotEquals(phone.getDetailString(), "Nonsense"); //to show it's actually matching the string
     }
 
     @Test
     void getValue_equals_input() {
         Phone phone = new Phone("999");
-        assertEquals(phone.getValue(),"999");
+        assertEquals(phone.getValue(), "999");
         assertNotEquals(phone.getValue(), "Nonsense"); //to show it's actually matching the string
     }
 }

--- a/src/test/java/connexion/model/person/PhoneTest.java
+++ b/src/test/java/connexion/model/person/PhoneTest.java
@@ -1,7 +1,9 @@
 package connexion.model.person;
 
 import static connexion.testutil.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -56,5 +58,19 @@ public class PhoneTest {
 
         // different values -> returns false
         assertFalse(phone.equals(new Phone("995")));
+    }
+
+    @Test
+    void getDetailString_equals_input() {
+        Phone phone = new Phone("999");
+        assertEquals(phone.getDetailString(),"999");
+        assertNotEquals(phone.getDetailString(), "Nonsense"); //to show it's actually matching the string
+    }
+
+    @Test
+    void getValue_equals_input() {
+        Phone phone = new Phone("999");
+        assertEquals(phone.getValue(),"999");
+        assertNotEquals(phone.getValue(), "Nonsense"); //to show it's actually matching the string
     }
 }

--- a/src/test/java/connexion/model/tag/TagTest.java
+++ b/src/test/java/connexion/model/tag/TagTest.java
@@ -6,8 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import connexion.model.person.Company;
-import connexion.model.person.Name;
 import org.junit.jupiter.api.Test;
 
 public class TagTest {
@@ -32,21 +30,21 @@ public class TagTest {
     @Test
     void getDetailString_equals_input() {
         Tag tag = new Tag("valid");
-        assertEquals(tag.getDetailString(),"valid");
+        assertEquals(tag.getDetailString(), "valid");
         assertNotEquals(tag.getDetailString(), "Nonsense"); //to show it's actually matching the string
     }
 
     @Test
     void getValue_equals_input() {
         Tag tag = new Tag("valid");
-        assertEquals(tag.getValue(),"valid");
+        assertEquals(tag.getValue(), "valid");
         assertNotEquals(tag.getValue(), "Nonsense"); //to show it's actually matching the string
     }
 
     @Test
     void getListString_equals_input() {
         Tag tag = new Tag("valid");
-        assertEquals(tag.getListString(),"valid");
+        assertEquals(tag.getListString(), "valid");
         assertNotEquals(tag.getListString(), "Nonsense"); //to show it's actually matching the string
     }
 

--- a/src/test/java/connexion/model/tag/TagTest.java
+++ b/src/test/java/connexion/model/tag/TagTest.java
@@ -1,7 +1,13 @@
 package connexion.model.tag;
 
 import static connexion.testutil.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import connexion.model.person.Company;
+import connexion.model.person.Name;
 import org.junit.jupiter.api.Test;
 
 public class TagTest {
@@ -23,4 +29,44 @@ public class TagTest {
         assertThrows(NullPointerException.class, () -> Tag.isValidTagName(null));
     }
 
+    @Test
+    void getDetailString_equals_input() {
+        Tag tag = new Tag("valid");
+        assertEquals(tag.getDetailString(),"valid");
+        assertNotEquals(tag.getDetailString(), "Nonsense"); //to show it's actually matching the string
+    }
+
+    @Test
+    void getValue_equals_input() {
+        Tag tag = new Tag("valid");
+        assertEquals(tag.getValue(),"valid");
+        assertNotEquals(tag.getValue(), "Nonsense"); //to show it's actually matching the string
+    }
+
+    @Test
+    void getListString_equals_input() {
+        Tag tag = new Tag("valid");
+        assertEquals(tag.getListString(),"valid");
+        assertNotEquals(tag.getListString(), "Nonsense"); //to show it's actually matching the string
+    }
+
+    @Test
+    void equals() {
+        Tag tag = new Tag("valid");
+
+        // same values -> returns true
+        assertTrue(tag.equals(new Tag("valid")));
+
+        // same object -> returns true
+        assertTrue(tag.equals(tag));
+
+        // null -> returns false
+        assertFalse(tag.equals(null));
+
+        // different types -> returns false
+        assertFalse(tag.equals(5.0f));
+
+        // different values -> returns false
+        assertFalse(tag.equals(new Tag("other")));
+    }
 }

--- a/src/test/java/connexion/testutil/PersonUtil.java
+++ b/src/test/java/connexion/testutil/PersonUtil.java
@@ -31,13 +31,14 @@ public class PersonUtil {
      */
     public static String getPersonDetails(Person person) {
         StringBuilder sb = new StringBuilder();
-        sb.append(PREFIX_NAME + person.getName().fullName + " ");
-        sb.append(PREFIX_PHONE + person.getPhone().value + " ");
-        sb.append(PREFIX_EMAIL + person.getEmail().value + " ");
-        sb.append(PREFIX_COMPANY + person.getCompany().value + " ");
-        sb.append(PREFIX_JOB + person.getJob().value + " ");
+        sb.append(PREFIX_NAME + person.getName().getValue() + " ");
+        sb.append(PREFIX_PHONE + person.getPhone().getValue() + " ");
+        sb.append(PREFIX_EMAIL + person.getEmail().getValue() + " ");
+        sb.append(PREFIX_COMPANY + person.getCompany().getDetailString() + " ");
+        sb.append(PREFIX_JOB + person.getJob().getValue() + " ");
         person.getTags().stream().forEach(
-            s -> sb.append(PREFIX_TAG + s.tagName + " ")
+            s -> sb.append(PREFIX_TAG + s.getValue() + " ")
+                // here, s is the tag. This code appends each tag w/ prefixes in to toString
         );
         return sb.toString();
     }
@@ -47,17 +48,17 @@ public class PersonUtil {
      */
     public static String getEditPersonDescriptorDetails(EditPersonDescriptor descriptor) {
         StringBuilder sb = new StringBuilder();
-        descriptor.getName().ifPresent(name -> sb.append(PREFIX_NAME).append(name.fullName).append(" "));
-        descriptor.getPhone().ifPresent(phone -> sb.append(PREFIX_PHONE).append(phone.value).append(" "));
-        descriptor.getEmail().ifPresent(email -> sb.append(PREFIX_EMAIL).append(email.value).append(" "));
-        descriptor.getCompany().ifPresent(company -> sb.append(PREFIX_COMPANY).append(company.value).append(" "));
-        descriptor.getJob().ifPresent(job -> sb.append(PREFIX_JOB).append(job.value).append(" "));
+        descriptor.getName().ifPresent(name -> sb.append(PREFIX_NAME).append(name.getValue()).append(" "));
+        descriptor.getPhone().ifPresent(phone -> sb.append(PREFIX_PHONE).append(phone.getValue()).append(" "));
+        descriptor.getEmail().ifPresent(email -> sb.append(PREFIX_EMAIL).append(email.getValue()).append(" "));
+        descriptor.getCompany().ifPresent(company -> sb.append(PREFIX_COMPANY).append(company.getValue()).append(" "));
+        descriptor.getJob().ifPresent(job -> sb.append(PREFIX_JOB).append(job.getValue()).append(" "));
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();
             if (tags.isEmpty()) {
                 sb.append(PREFIX_TAG);
             } else {
-                tags.forEach(s -> sb.append(PREFIX_TAG).append(s.tagName).append(" "));
+                tags.forEach(s -> sb.append(PREFIX_TAG).append(s.getValue()).append(" "));
             }
         }
         return sb.toString();

--- a/src/test/java/connexion/testutil/PersonUtil.java
+++ b/src/test/java/connexion/testutil/PersonUtil.java
@@ -38,7 +38,7 @@ public class PersonUtil {
         sb.append(PREFIX_JOB + person.getJob().getValue() + " ");
         person.getTags().stream().forEach(
             s -> sb.append(PREFIX_TAG + s.getValue() + " ")
-                // here, s is the tag. This code appends each tag w/ prefixes in to toString
+        // here, s is the tag. This code appends each tag w/ prefixes in to toString
         );
         return sb.toString();
     }


### PR DESCRIPTION
Closes #140 

> Interfaces will have following methods :
> 
> 1. `getValue` for all fields
> 2. `getListString` for all fields that are to be viewed in the small list view
> 3. `getDetailString` for all fields that are to be viewed in detail view (which as of last discussion was every one of them)
> 
> Note that only some interfaces guarantee some methods, i.e : `PersonField` will guarantee `getValue`, `PersonListField` will guarantee `getListString`, `PersonDetailField` will guarantee `getDetailString`, `PersonListDetailField` will guarantee both `getListString`, `getDetailString`



List of changes in code made :

1. Creation of `PersonField` interface & children
2. Refactoring of all references in UI to use `getListView`
3. Refactoring of all references in storage code to use `toString`
4. Refactoring of all references in non-UI, non-storage code to use `getValue`
5. Refactoring of old test cases to use `getValue` where they referenced the values directly from the class (`PersonUtil`, `ModelManagerTest`, `CommandTestUtil`)
6. Addition of new test cases for new methods (`getValue`, `getListString`, `getDetailString`)
