### PR TITLE
Add schedule stub

### DIFF
--- a/src/main/java/connexion/model/person/Schedule.java
+++ b/src/main/java/connexion/model/person/Schedule.java
@@ -1,0 +1,28 @@
+package connexion.model.person;
+
+import jdk.jshell.spi.ExecutionControl;
+
+import java.time.LocalDateTime;
+
+import static jdk.jshell.spi.ExecutionControl.NotImplementedException;
+
+public abstract class Schedule implements PersonListDetailField<LocalDateTime>{
+
+    /**
+     * Returns the user-facing string representation of this field in a detail view.
+     */
+    @Override
+    public abstract String getDetailString();
+
+    /**
+     * Returns the value within this field.
+     */
+    @Override
+    public abstract LocalDateTime getValue();
+
+    /**
+     * Returns the user-facing string representation of this field in an at-a-glance view.
+     */
+    @Override
+    public abstract String getListString();
+}

--- a/src/main/java/connexion/model/person/Schedule.java
+++ b/src/main/java/connexion/model/person/Schedule.java
@@ -1,12 +1,13 @@
 package connexion.model.person;
 
-import jdk.jshell.spi.ExecutionControl;
 
 import java.time.LocalDateTime;
 
-import static jdk.jshell.spi.ExecutionControl.NotImplementedException;
 
-public abstract class Schedule implements PersonListDetailField<LocalDateTime>{
+/**
+ * Class representing a schedule in Person. TO BE IMPLEMENTED
+ */
+public abstract class Schedule implements PersonListDetailField<LocalDateTime> {
 
     /**
      * Returns the user-facing string representation of this field in a detail view.

--- a/src/main/java/connexion/model/person/ScheduleStub.java
+++ b/src/main/java/connexion/model/person/ScheduleStub.java
@@ -4,25 +4,28 @@ import java.time.LocalDateTime;
 import java.time.Period;
 import java.time.format.DateTimeFormatter;
 
-public class ScheduleStub extends Schedule{
+/**
+ * Temp stub for detail implementation injection
+ */
+public class ScheduleStub extends Schedule {
 
-    private static LocalDateTime DEFAULT_SCHEDULE_TIME = LastModifiedDateTime.DEFAULT_LAST_MODIFIED;
+    private static final LocalDateTime DEFAULT_SCHEDULE_TIME = LastModifiedDateTime.DEFAULT_LAST_MODIFIED;
 
-    private static DateTimeFormatter LIST_FORMATTER = DateTimeFormatter.ofPattern("dd MM yy");
-    private static Period IN_TIME = Period.of(1,1,1);
+    private static final DateTimeFormatter LIST_FORMATTER = DateTimeFormatter.ofPattern("dd MMM");
+    private static final Period IN_TIME = Period.of(1, 1, 1);
 
-    private static DateTimeFormatter DETAIL_FORMATTER = DateTimeFormatter.ofPattern("dd/MMM/yyyy");
-    public ScheduleStub(){
+    private static final DateTimeFormatter DETAIL_FORMATTER = DateTimeFormatter.ofPattern("dd/MMM/yyyy");
+    public ScheduleStub() {
         // does nothing
     }
 
 
-    /**-
+    /**
      * Returns the user-facing string representation of this field in a detail view.
      */
     @Override
     public String getDetailString() {
-        return DEFAULT_SCHEDULE_TIME.format(DETAIL_FORMATTER) + String.format(" (in %s years)", IN_TIME.getYears());
+        return DEFAULT_SCHEDULE_TIME.format(DETAIL_FORMATTER) + String.format(" (in %s year)", IN_TIME.getYears());
     }
 
     /**
@@ -38,6 +41,6 @@ public class ScheduleStub extends Schedule{
      */
     @Override
     public String getListString() {
-        return DEFAULT_SCHEDULE_TIME.format(LIST_FORMATTER) + String.format(" (in %s years)", IN_TIME.getYears());
+        return DEFAULT_SCHEDULE_TIME.format(LIST_FORMATTER) + String.format(" (in %s year)", IN_TIME.getYears());
     }
 }

--- a/src/main/java/connexion/model/person/ScheduleStub.java
+++ b/src/main/java/connexion/model/person/ScheduleStub.java
@@ -1,0 +1,43 @@
+package connexion.model.person;
+
+import java.time.LocalDateTime;
+import java.time.Period;
+import java.time.format.DateTimeFormatter;
+
+public class ScheduleStub extends Schedule{
+
+    private static LocalDateTime DEFAULT_SCHEDULE_TIME = LastModifiedDateTime.DEFAULT_LAST_MODIFIED;
+
+    private static DateTimeFormatter LIST_FORMATTER = DateTimeFormatter.ofPattern("dd MM yy");
+    private static Period IN_TIME = Period.of(1,1,1);
+
+    private static DateTimeFormatter DETAIL_FORMATTER = DateTimeFormatter.ofPattern("dd/MMM/yyyy");
+    public ScheduleStub(){
+        // does nothing
+    }
+
+
+    /**-
+     * Returns the user-facing string representation of this field in a detail view.
+     */
+    @Override
+    public String getDetailString() {
+        return DEFAULT_SCHEDULE_TIME.format(DETAIL_FORMATTER) + String.format(" (in %s years)", IN_TIME.getYears());
+    }
+
+    /**
+     * Returns the value within this field.
+     */
+    @Override
+    public LocalDateTime getValue() {
+        return DEFAULT_SCHEDULE_TIME;
+    }
+
+    /**
+     * Returns the user-facing string representation of this field in an at-a-glance view.
+     */
+    @Override
+    public String getListString() {
+        return DEFAULT_SCHEDULE_TIME.format(LIST_FORMATTER) + String.format(" (in %s years)", IN_TIME.getYears());
+    }
+}

--- a/src/test/java/connexion/model/person/ScheduleStubTest.java
+++ b/src/test/java/connexion/model/person/ScheduleStubTest.java
@@ -1,0 +1,31 @@
+package connexion.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+
+
+
+class ScheduleStubTest {
+
+    // LocalDateTime.of(
+    //            2000, 10, 10, 10, 10)
+    @Test
+    void getDetailString() {
+        assertEquals("10/Oct/2000 (in 1 year)", new ScheduleStub().getDetailString());
+    }
+
+    @Test
+    void getValue() {
+        assertEquals(LocalDateTime.of(
+                2000, 10, 10, 10, 10),
+                new ScheduleStub().getValue());
+    }
+
+    @Test
+    void getListString() {
+        assertEquals("10 Oct (in 1 year)", new ScheduleStub().getListString());
+    }
+}


### PR DESCRIPTION
Adds schedule stub for implementation in new `detail `feature @Angelyxx 

Only adds schedule stub w/ interface methods, linking into Person, etc., has to be done by dev implementing `detail` feature.\

Expected output is  : 
`10/Oct/2000 (in 1 year)` for `getDetailString`
`10 Oct (in 1 year)` for `getListString`
A `LocalDateTime` set to (year : 2000, month : 10, day : 10, hour : 10, minute : 10) for `getValue`

Expected output can be references from test cases, which are hard-coded!

@geoffong11, please confirm if this is the format we want for `schedule` eventually!