### PR TITLE
Change LastModifiedDateTime to be strict

### DIFF
--- a/src/main/java/connexion/model/person/LastModifiedDateTime.java
+++ b/src/main/java/connexion/model/person/LastModifiedDateTime.java
@@ -7,9 +7,8 @@ import static java.util.Objects.requireNonNull;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.time.format.FormatStyle;
+import java.time.format.ResolverStyle;
 import java.time.temporal.ChronoUnit;
-import java.util.Locale;
 
 
 /**
@@ -35,9 +34,7 @@ public class LastModifiedDateTime implements PersonDetailField<LocalDateTime> {
      *
      */
     public static final DateTimeFormatter LASTMODIFIED_FORMATTER =
-            DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM)
-                    .withLocale(Locale.UK);
-
+            DateTimeFormatter.ofPattern("d MMM uuuu, HH:mm:ss").withResolverStyle(ResolverStyle.STRICT);
     private LocalDateTime lastModified;
 
 

--- a/src/test/java/connexion/model/person/LastModifiedDateTimeTest.java
+++ b/src/test/java/connexion/model/person/LastModifiedDateTimeTest.java
@@ -40,23 +40,44 @@ class LastModifiedDateTimeTest {
 
         // invalid LastModifiedDateTimes
         assertFalse(LastModifiedDateTime.isValidLastModifiedDateTime("")); // empty string
+        // Nonsensical input
         assertFalse(LastModifiedDateTime.isValidLastModifiedDateTime("1 abc 1999, 10:09:00"));
-        // nonsensical field
+        // Nonsensical input using other characters like -
+        assertFalse(LastModifiedDateTime.isValidLastModifiedDateTime("-1 Jan 1999, 10:61:00"));
+        // Invalid field (Day)
         assertFalse(LastModifiedDateTime.isValidLastModifiedDateTime("40 Jan 1999, 10:09:00"));
-        // invalid field
+        // invalid field (Hour)
         assertFalse(LastModifiedDateTime.isValidLastModifiedDateTime("1 Jan 1999, 24:09:00"));
+        // invalid field (Minute)
+        assertFalse(LastModifiedDateTime.isValidLastModifiedDateTime("1 Jan 1999, 10:61:00"));
+        // invalid field (Apr 2020 had 30 days)
+        assertFalse(LastModifiedDateTime.isValidLastModifiedDateTime("31 Apr 2020, 10:09:00"));
+        // invalid field (Feb 1999 had 28 days)
+        assertFalse(LastModifiedDateTime.isValidLastModifiedDateTime("29 Feb 1999, 10:09:00"));
+        // invalid field (Feb 2000 had 29 days)
+        assertFalse(LastModifiedDateTime.isValidLastModifiedDateTime("30 Feb 2000, 10:09:00"));
+
         // another invalid field
         assertFalse(LastModifiedDateTime.isValidLastModifiedDateTime(
                 DEFAULT_TEST_TIME.format(
                         DateTimeFormatter.ISO_LOCAL_DATE_TIME)));
-        // Valid input, but in wrong format
+        // Valid input, but in wrong format (comma misplaced)
         assertFalse(LastModifiedDateTime.isValidLastModifiedDateTime("1 Jan, 1999 10:09:00"));
+        // Valid input, but in wrong format (Jan not capitalised)
+        assertFalse(LastModifiedDateTime.isValidLastModifiedDateTime("1 jan 1999, 10:09:00"));
 
         // valid LastModifiedDateTimes
         assertTrue(LastModifiedDateTime.isValidLastModifiedDateTime("1 Jan 1999, 10:09:00"));
         assertTrue(LastModifiedDateTime.isValidLastModifiedDateTime(
                 DEFAULT_TEST_TIME.format(
                         LastModifiedDateTime.LASTMODIFIED_FORMATTER)));
+        // valid field (Apr 2020 had 30 days)
+        assertTrue(LastModifiedDateTime.isValidLastModifiedDateTime("30 Apr 2020, 10:09:00"));
+        // valid field (Feb 1999 had 28 days)
+        assertTrue(LastModifiedDateTime.isValidLastModifiedDateTime("28 Feb 1999, 10:09:00"));
+        // valid field (Feb 2000 had 29 days)
+        assertTrue(LastModifiedDateTime.isValidLastModifiedDateTime("29 Feb 2000, 10:09:00"));
+
     }
 
     @Test

--- a/src/test/java/connexion/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/connexion/storage/JsonAdaptedPersonTest.java
@@ -229,6 +229,8 @@ public class JsonAdaptedPersonTest {
 
     @Test
     public void toModelType_invalidLastModifiedDateTime_throwsIllegalValueException() {
+        // More exhaustive testing of variations that are invalid carried out in LastModifiedDateTimeTest
+        // Testing there includes finer details of format checking & validation.
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE,
                         VALID_EMAIL, VALID_COMPANY, VALID_JOB, VALID_TAGS, VALID_MARK_STATUS,


### PR DESCRIPTION
Closes #190 

Makes parsing stricter

Note change in format to have a singular `d` does still display 2-digit days correctly.
See screenshot (Taken from build as of the branch I'm PR-ing). 

Updates test cases to cover the bugs raised in the linked issue (i.e. day-parsing). 

Passes all test cases.

 New formatter matches old formatter in terms of output (see screenshot also)

![image](https://github.com/AY2324S1-CS2103-F13-1/tp/assets/54708640/2f0c8fc4-cc6f-4bf0-b716-7719b146269e)
