### PR TITLE
Change tag error message to correctly reflect error user faces.

### DIFF
--- a/src/main/java/connexion/model/tag/Tag.java
+++ b/src/main/java/connexion/model/tag/Tag.java
@@ -11,8 +11,8 @@ import connexion.model.person.PersonListDetailField;
  */
 public class Tag implements PersonListDetailField<String> {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tag name(s) should be alphanumeric" +
-            " & consist of only one word not separated by whitespace";
+    public static final String MESSAGE_CONSTRAINTS = "Tag name(s) should be alphanumeric"
+            + " & consist of only one word not separated by whitespace";
     public static final String VALIDATION_REGEX = "\\p{Alnum}+";
 
     private final String tagName;

--- a/src/main/java/connexion/model/tag/Tag.java
+++ b/src/main/java/connexion/model/tag/Tag.java
@@ -11,7 +11,8 @@ import connexion.model.person.PersonListDetailField;
  */
 public class Tag implements PersonListDetailField<String> {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
+    public static final String MESSAGE_CONSTRAINTS = "Tag name(s) should be alphanumeric" +
+            " & consist of only one word not separated by whitespace";
     public static final String VALIDATION_REGEX = "\\p{Alnum}+";
 
     private final String tagName;


### PR DESCRIPTION
Error message informs user that must be alphanumeric

Incorrect, full constraint includes one word

Previous  :
![image](https://github.com/AY2324S1-CS2103-F13-1/tp/assets/54708640/bdae5870-ec60-4cd8-8b6f-f078fd9e3a45)

Current : 
![image](https://github.com/AY2324S1-CS2103-F13-1/tp/assets/54708640/e0ae6122-7523-4356-abc5-db56dd8f2e8b)

Closes #164 