### PR TITLE
Update parsing & all field parsing error message & UG to reflect behaviour

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -134,6 +134,8 @@ Format: `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [c/COMPANY] [j/JOB] [t/T
 * When editing tags, the existing tags of the contact will be removed i.e. adding of tags is not cumulative.
 * You can remove all the contact’s tags by typing `t/` without
   specifying any tags after it.
+  * This is the only time `t/` allows an empty parameter supplied.
+  * In the case that **more than one** `t/` is present, typing `t/` without any tags after be interpreted as attempting to add an empty tag (not allowed!)
 * Same as `add`, no duplicate names (case-sensitive) are allowed.
 * Updates the last modified time of the given contact to the current time when executed.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -48,19 +48,33 @@ title: User Guide
 * Words in `UPPER_CASE` are the parameters to be supplied by the user.<br>
   e.g. in `add n/NAME`, `NAME` is a parameter which can be used as `add n/John Doe`.
 
+
 * Items in square brackets are optional.<br>
   e.g. `n/NAME [t/TAG]` can be used as `n/John Doe t/friend` or as `n/John Doe`.
+
 
 * Items with `...​` after them can be used multiple times including zero times.<br>
   e.g. `[t/TAG]...​` can be used as ` ` (i.e. 0 times), `t/friend`, `t/friend t/family` etc.
 
+
 * Parameters can be in any order.<br>
   e.g. if the command specifies `n/NAME p/PHONE_NUMBER`, `p/PHONE_NUMBER n/NAME` is also acceptable.
 
-* Extraneous parameters for commands that do not take in parameters (such as `help`, `list`, `exit` and `clear`) will be ignored.<br>
+
+
+* Parameters not supported by a command **that accepts parameters** will be interpreted as part of the input _**including the prefix**_ 
+  e.g. `add n/Aiken Duit p/88888888 e/aikenduit@hotmail.com c/Meta j/Data Engineer a/ testScheduleName`will create a person with job `Data Engineer a/ testScheduleName`
+* This also applies for index  
+  e.g. `edit 1 a/scheduleName` will attempt to interpret the index as `1 a/scheduleName`, which is obviously invalid.
+* The above two can and often will result in invalid inputs.
+
+
+
+* Extraneous parameters for commands that **do not take in parameters** (such as `help`, `list`, `exit` and `clear`) will be ignored.<br>
   e.g. if the command specifies `help 123`, it will be interpreted as `help`.
 * Commands that modify contacts' detail or create contacts, i.e. `add` and `edit`, time-stamp the contact with a last modified field.
   * `mark` is not considered as modifying contact's detail and hence does not change the last modified date.
+
 * If you are using a PDF version of this document, be careful when copying and pasting commands that span multiple lines as space characters surrounding line-breaks may be omitted when copied over to the application.
 </div>
 

--- a/src/main/java/connexion/logic/Messages.java
+++ b/src/main/java/connexion/logic/Messages.java
@@ -14,6 +14,7 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
+    public static final String MESSAGE_INVALID_FIELD_FORMAT = MESSAGE_INVALID_COMMAND_FORMAT + "\n%2$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =

--- a/src/main/java/connexion/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/connexion/logic/parser/DeleteCommandParser.java
@@ -1,6 +1,5 @@
 package connexion.logic.parser;
 
-import static connexion.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static connexion.logic.Messages.MESSAGE_INVALID_FIELD_FORMAT;
 
 import connexion.commons.core.index.Index;

--- a/src/main/java/connexion/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/connexion/logic/parser/DeleteCommandParser.java
@@ -22,7 +22,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
             return new DeleteCommand(index);
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, pe.getMessage() + "\n" + DeleteCommand.MESSAGE_USAGE), pe);
         }
     }
 

--- a/src/main/java/connexion/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/connexion/logic/parser/DeleteCommandParser.java
@@ -1,6 +1,7 @@
 package connexion.logic.parser;
 
 import static connexion.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static connexion.logic.Messages.MESSAGE_INVALID_FIELD_FORMAT;
 
 import connexion.commons.core.index.Index;
 import connexion.logic.commands.DeleteCommand;
@@ -22,7 +23,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
             return new DeleteCommand(index);
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, pe.getMessage() + "\n" + DeleteCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_FIELD_FORMAT, pe.getMessage(), DeleteCommand.MESSAGE_USAGE), pe);
         }
     }
 

--- a/src/main/java/connexion/logic/parser/DetailCommandParser.java
+++ b/src/main/java/connexion/logic/parser/DetailCommandParser.java
@@ -1,10 +1,8 @@
 package connexion.logic.parser;
 
-import static connexion.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static connexion.logic.Messages.MESSAGE_INVALID_FIELD_FORMAT;
 
 import connexion.commons.core.index.Index;
-import connexion.logic.commands.DeleteCommand;
 import connexion.logic.commands.DetailCommand;
 import connexion.logic.parser.exceptions.ParseException;
 

--- a/src/main/java/connexion/logic/parser/DetailCommandParser.java
+++ b/src/main/java/connexion/logic/parser/DetailCommandParser.java
@@ -1,8 +1,10 @@
 package connexion.logic.parser;
 
 import static connexion.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static connexion.logic.Messages.MESSAGE_INVALID_FIELD_FORMAT;
 
 import connexion.commons.core.index.Index;
+import connexion.logic.commands.DeleteCommand;
 import connexion.logic.commands.DetailCommand;
 import connexion.logic.parser.exceptions.ParseException;
 
@@ -21,7 +23,7 @@ public class DetailCommandParser implements Parser<DetailCommand> {
             return new DetailCommand(index);
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DetailCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_FIELD_FORMAT, pe.getMessage(), DetailCommand.MESSAGE_USAGE), pe);
         }
     }
 }

--- a/src/main/java/connexion/logic/parser/EditCommandParser.java
+++ b/src/main/java/connexion/logic/parser/EditCommandParser.java
@@ -1,6 +1,5 @@
 package connexion.logic.parser;
 
-import static connexion.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static connexion.logic.Messages.MESSAGE_INVALID_FIELD_FORMAT;
 import static connexion.logic.parser.CliSyntax.PREFIX_COMPANY;
 import static connexion.logic.parser.CliSyntax.PREFIX_EMAIL;
@@ -18,7 +17,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import connexion.commons.core.index.Index;
-import connexion.logic.commands.DeleteCommand;
 import connexion.logic.commands.EditCommand;
 import connexion.logic.commands.EditCommand.EditPersonDescriptor;
 import connexion.logic.parser.exceptions.ParseException;

--- a/src/main/java/connexion/logic/parser/EditCommandParser.java
+++ b/src/main/java/connexion/logic/parser/EditCommandParser.java
@@ -1,6 +1,7 @@
 package connexion.logic.parser;
 
 import static connexion.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static connexion.logic.Messages.MESSAGE_INVALID_FIELD_FORMAT;
 import static connexion.logic.parser.CliSyntax.PREFIX_COMPANY;
 import static connexion.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static connexion.logic.parser.CliSyntax.PREFIX_JOB;
@@ -17,6 +18,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import connexion.commons.core.index.Index;
+import connexion.logic.commands.DeleteCommand;
 import connexion.logic.commands.EditCommand;
 import connexion.logic.commands.EditCommand.EditPersonDescriptor;
 import connexion.logic.parser.exceptions.ParseException;
@@ -46,7 +48,8 @@ public class EditCommandParser implements ClockDependentParser<EditCommand> {
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(
+                    String.format(MESSAGE_INVALID_FIELD_FORMAT, pe.getMessage(), EditCommand.MESSAGE_USAGE)), pe);
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_COMPANY, PREFIX_JOB);

--- a/src/main/java/connexion/logic/parser/MarkCommandParser.java
+++ b/src/main/java/connexion/logic/parser/MarkCommandParser.java
@@ -1,10 +1,8 @@
 package connexion.logic.parser;
 
-import static connexion.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static connexion.logic.Messages.MESSAGE_INVALID_FIELD_FORMAT;
 
 import connexion.commons.core.index.Index;
-import connexion.logic.commands.DeleteCommand;
 import connexion.logic.commands.MarkCommand;
 import connexion.logic.parser.exceptions.ParseException;
 

--- a/src/main/java/connexion/logic/parser/MarkCommandParser.java
+++ b/src/main/java/connexion/logic/parser/MarkCommandParser.java
@@ -1,8 +1,10 @@
 package connexion.logic.parser;
 
 import static connexion.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static connexion.logic.Messages.MESSAGE_INVALID_FIELD_FORMAT;
 
 import connexion.commons.core.index.Index;
+import connexion.logic.commands.DeleteCommand;
 import connexion.logic.commands.MarkCommand;
 import connexion.logic.parser.exceptions.ParseException;
 
@@ -21,7 +23,7 @@ public class MarkCommandParser implements Parser<MarkCommand> {
             return new MarkCommand(index);
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_FIELD_FORMAT, pe.getMessage(), MarkCommand.MESSAGE_USAGE), pe);
         }
     }
 }

--- a/src/main/java/connexion/logic/parser/NoteCommandParser.java
+++ b/src/main/java/connexion/logic/parser/NoteCommandParser.java
@@ -9,7 +9,6 @@ import java.time.Clock;
 import java.time.LocalDateTime;
 
 import connexion.commons.core.index.Index;
-import connexion.logic.commands.DeleteCommand;
 import connexion.logic.commands.NoteCommand;
 import connexion.logic.commands.NoteCommand.NoteDescriptor;
 import connexion.logic.parser.exceptions.ParseException;

--- a/src/main/java/connexion/logic/parser/NoteCommandParser.java
+++ b/src/main/java/connexion/logic/parser/NoteCommandParser.java
@@ -1,6 +1,7 @@
 package connexion.logic.parser;
 
 import static connexion.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static connexion.logic.Messages.MESSAGE_INVALID_FIELD_FORMAT;
 import static connexion.logic.parser.CliSyntax.PREFIX_NOTE;
 import static java.util.Objects.requireNonNull;
 
@@ -8,6 +9,7 @@ import java.time.Clock;
 import java.time.LocalDateTime;
 
 import connexion.commons.core.index.Index;
+import connexion.logic.commands.DeleteCommand;
 import connexion.logic.commands.NoteCommand;
 import connexion.logic.commands.NoteCommand.NoteDescriptor;
 import connexion.logic.parser.exceptions.ParseException;
@@ -34,7 +36,8 @@ public class NoteCommandParser implements ClockDependentParser<NoteCommand> {
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, NoteCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_FIELD_FORMAT,
+                    pe.getMessage(), NoteCommand.MESSAGE_USAGE), pe);
         }
 
         if (!isNotePrefixPresent(argMultimap)) {

--- a/src/main/java/connexion/logic/parser/ParserUtil.java
+++ b/src/main/java/connexion/logic/parser/ParserUtil.java
@@ -28,6 +28,7 @@ public class ParserUtil {
     public static final String MESSAGE_INDEX_EXCEEDS_INT_LIMIT =
             "Index exceeds the allowed integer limit in Java of 2147483647";
 
+
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
      * trimmed.
@@ -45,9 +46,7 @@ public class ParserUtil {
         } else if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
             // else, it's likely an out-of-bounds error
             throw new ParseException(MESSAGE_INDEX_EXCEEDS_INT_LIMIT);
-        if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
-            throw new ParseException("Invalid index given: " + trimmedIndex + "\n"
-                    + MESSAGE_INVALID_INDEX);
+
         }
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));
     }

--- a/src/main/java/connexion/logic/parser/ParserUtil.java
+++ b/src/main/java/connexion/logic/parser/ParserUtil.java
@@ -34,7 +34,8 @@ public class ParserUtil {
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
         String trimmedIndex = oneBasedIndex.trim();
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
-            throw new ParseException(MESSAGE_INVALID_INDEX);
+            throw new ParseException("Invalid index given: " + trimmedIndex + "\n"
+                    + MESSAGE_INVALID_INDEX);
         }
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));
     }
@@ -49,7 +50,8 @@ public class ParserUtil {
         requireNonNull(name);
         String trimmedName = name.trim();
         if (!Name.isValidName(trimmedName)) {
-            throw new ParseException(Name.MESSAGE_CONSTRAINTS);
+            throw new ParseException("Invalid name given: " + trimmedName + "\n"
+                    + Name.MESSAGE_CONSTRAINTS);
         }
         return new Name(trimmedName);
     }
@@ -64,7 +66,8 @@ public class ParserUtil {
         requireNonNull(phone);
         String trimmedPhone = phone.trim();
         if (!Phone.isValidPhone(trimmedPhone)) {
-            throw new ParseException(Phone.MESSAGE_CONSTRAINTS);
+            throw new ParseException("Invalid phone number given: " + trimmedPhone + "\n"
+                    + Phone.MESSAGE_CONSTRAINTS);
         }
         return new Phone(trimmedPhone);
     }
@@ -79,7 +82,8 @@ public class ParserUtil {
         requireNonNull(company);
         String trimmedCompany = company.trim();
         if (!Company.isValidCompany(trimmedCompany)) {
-            throw new ParseException(Company.MESSAGE_CONSTRAINTS);
+            throw new ParseException("Invalid company name given: " + company + "\n"
+                    + Company.MESSAGE_CONSTRAINTS);
         }
         return new Company(trimmedCompany);
     }
@@ -94,7 +98,8 @@ public class ParserUtil {
         requireNonNull(job);
         String trimmedJob = job.trim();
         if (!Job.isValidJob(trimmedJob)) {
-            throw new ParseException(Job.MESSAGE_CONSTRAINTS);
+            throw new ParseException("Invalid job given: " + job + "\n"
+                    + Job.MESSAGE_CONSTRAINTS);
         }
         return new Job(trimmedJob);
     }
@@ -109,7 +114,8 @@ public class ParserUtil {
         requireNonNull(email);
         String trimmedEmail = email.trim();
         if (!Email.isValidEmail(trimmedEmail)) {
-            throw new ParseException(Email.MESSAGE_CONSTRAINTS);
+            throw new ParseException("Invalid email given: " + email + "\n"
+                    + Email.MESSAGE_CONSTRAINTS);
         }
         return new Email(trimmedEmail);
     }
@@ -124,7 +130,8 @@ public class ParserUtil {
         requireNonNull(schedule);
         String trimmedSchedule = schedule.trim();
         if (!Schedule.isValidScheduleTime(trimmedSchedule)) {
-            throw new ParseException(Schedule.MESSAGE_CONSTRAINTS);
+            throw new ParseException("Invalid schedule given: " + schedule + "\n"
+                    + Schedule.MESSAGE_CONSTRAINTS);
         }
         return new Schedule(trimmedSchedule);
     }
@@ -139,7 +146,8 @@ public class ParserUtil {
         requireNonNull(scheduleName);
         String trimmedScheduleName = scheduleName.trim();
         if (!ScheduleName.isValidScheduleName(trimmedScheduleName)) {
-            throw new ParseException(ScheduleName.MESSAGE_CONSTRAINTS);
+            throw new ParseException("Invalid schedule name given: " + trimmedScheduleName + "\n"
+                    + ScheduleName.MESSAGE_CONSTRAINTS);
         }
         return new ScheduleName(trimmedScheduleName);
     }
@@ -154,7 +162,8 @@ public class ParserUtil {
         requireNonNull(tag);
         String trimmedTag = tag.trim();
         if (!Tag.isValidTagName(trimmedTag)) {
-            throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
+            throw new ParseException("Invalid tag given: " + trimmedTag + "\n"
+                    + Tag.MESSAGE_CONSTRAINTS);
         }
         return new Tag(trimmedTag);
     }
@@ -181,7 +190,8 @@ public class ParserUtil {
         requireNonNull(note);
         String trimmedNote = note.trim();
         if (!Note.isValidNote(trimmedNote)) {
-            throw new ParseException(Note.MESSAGE_CONSTRAINTS);
+            throw new ParseException("Invalid note given: " + trimmedNote + "\n"
+                    + Note.MESSAGE_CONSTRAINTS);
         } else if (!Note.hasValidLength(trimmedNote)) {
             throw new ParseException(Note.MESSAGE_CONSTRAINTS_CHARACTER_LIMIT);
         }

--- a/src/main/java/connexion/logic/parser/ParserUtil.java
+++ b/src/main/java/connexion/logic/parser/ParserUtil.java
@@ -28,7 +28,14 @@ public class ParserUtil {
     public static final String MESSAGE_INDEX_EXCEEDS_INT_LIMIT =
             "Index exceeds the allowed integer limit in Java of 2147483647";
 
-
+    /**
+     * Constructs an exception message given the type, the (invalid) value, & the final feedback message to give user
+     *
+     * @return A string of format "Invalid {fieldType} given: {invalidValue}\n {feedbackMessage}
+     */
+    private static String makeExceptionMessage(String fieldType, String invalidValue, String feedbackMessage) {
+        return String.format("Invalid %s given: %s\n%s", fieldType, invalidValue, feedbackMessage);
+    }
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
      * trimmed.
@@ -39,13 +46,16 @@ public class ParserUtil {
         if (!((trimmedIndex).matches("\\d+"))) {
             //if it's not just digits, clearly wrong
             //notably, this catches -ve numbers (as the "-" causes it to fail the check)
-            throw new ParseException((MESSAGE_INVALID_INDEX));
+            throw new ParseException(makeExceptionMessage("index", trimmedIndex,
+                    MESSAGE_INVALID_INDEX));
         } else if (trimmedIndex.matches("0+")) {
             //if it's some amount of just zeros, also wrong
-            throw new ParseException(MESSAGE_INVALID_INDEX);
+            throw new ParseException(makeExceptionMessage("index", trimmedIndex,
+                    MESSAGE_INVALID_INDEX));
         } else if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
             // else, it's likely an out-of-bounds error
-            throw new ParseException(MESSAGE_INDEX_EXCEEDS_INT_LIMIT);
+            throw new ParseException(makeExceptionMessage("index", trimmedIndex,
+                    MESSAGE_INDEX_EXCEEDS_INT_LIMIT));
 
         }
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));
@@ -61,8 +71,8 @@ public class ParserUtil {
         requireNonNull(name);
         String trimmedName = name.trim();
         if (!Name.isValidName(trimmedName)) {
-            throw new ParseException("Invalid name given: " + trimmedName + "\n"
-                    + Name.MESSAGE_CONSTRAINTS);
+            throw new ParseException(makeExceptionMessage("name", trimmedName,
+                    Name.MESSAGE_CONSTRAINTS));
         }
         return new Name(trimmedName);
     }
@@ -77,8 +87,8 @@ public class ParserUtil {
         requireNonNull(phone);
         String trimmedPhone = phone.trim();
         if (!Phone.isValidPhone(trimmedPhone)) {
-            throw new ParseException("Invalid phone number given: " + trimmedPhone + "\n"
-                    + Phone.MESSAGE_CONSTRAINTS);
+            throw new ParseException(makeExceptionMessage("phone number", trimmedPhone,
+                    Phone.MESSAGE_CONSTRAINTS));
         }
         return new Phone(trimmedPhone);
     }
@@ -93,8 +103,8 @@ public class ParserUtil {
         requireNonNull(company);
         String trimmedCompany = company.trim();
         if (!Company.isValidCompany(trimmedCompany)) {
-            throw new ParseException("Invalid company name given: " + company + "\n"
-                    + Company.MESSAGE_CONSTRAINTS);
+            throw new ParseException(makeExceptionMessage("company name", trimmedCompany,
+                    Company.MESSAGE_CONSTRAINTS));
         }
         return new Company(trimmedCompany);
     }
@@ -109,8 +119,8 @@ public class ParserUtil {
         requireNonNull(job);
         String trimmedJob = job.trim();
         if (!Job.isValidJob(trimmedJob)) {
-            throw new ParseException("Invalid job given: " + job + "\n"
-                    + Job.MESSAGE_CONSTRAINTS);
+            throw new ParseException(makeExceptionMessage("job", trimmedJob,
+                    Job.MESSAGE_CONSTRAINTS));
         }
         return new Job(trimmedJob);
     }
@@ -125,8 +135,8 @@ public class ParserUtil {
         requireNonNull(email);
         String trimmedEmail = email.trim();
         if (!Email.isValidEmail(trimmedEmail)) {
-            throw new ParseException("Invalid email given: " + email + "\n"
-                    + Email.MESSAGE_CONSTRAINTS);
+            throw new ParseException(makeExceptionMessage("email", trimmedEmail,
+                    Email.MESSAGE_CONSTRAINTS));
         }
         return new Email(trimmedEmail);
     }
@@ -141,8 +151,8 @@ public class ParserUtil {
         requireNonNull(schedule);
         String trimmedSchedule = schedule.trim();
         if (!Schedule.isValidScheduleTime(trimmedSchedule)) {
-            throw new ParseException("Invalid schedule given: " + schedule + "\n"
-                    + Schedule.MESSAGE_CONSTRAINTS);
+            throw new ParseException(makeExceptionMessage("schedule", schedule,
+                    Schedule.MESSAGE_CONSTRAINTS));
         }
         return new Schedule(trimmedSchedule);
     }
@@ -157,8 +167,8 @@ public class ParserUtil {
         requireNonNull(scheduleName);
         String trimmedScheduleName = scheduleName.trim();
         if (!ScheduleName.isValidScheduleName(trimmedScheduleName)) {
-            throw new ParseException("Invalid schedule name given: " + trimmedScheduleName + "\n"
-                    + ScheduleName.MESSAGE_CONSTRAINTS);
+            throw new ParseException(makeExceptionMessage("schedule name", trimmedScheduleName,
+                    ScheduleName.MESSAGE_CONSTRAINTS));
         }
         return new ScheduleName(trimmedScheduleName);
     }
@@ -173,8 +183,8 @@ public class ParserUtil {
         requireNonNull(tag);
         String trimmedTag = tag.trim();
         if (!Tag.isValidTagName(trimmedTag)) {
-            throw new ParseException("Invalid tag given: " + trimmedTag + "\n"
-                    + Tag.MESSAGE_CONSTRAINTS);
+            throw new ParseException(makeExceptionMessage("tag", trimmedTag,
+                    Tag.MESSAGE_CONSTRAINTS));
         }
         return new Tag(trimmedTag);
     }
@@ -201,8 +211,8 @@ public class ParserUtil {
         requireNonNull(note);
         String trimmedNote = note.trim();
         if (!Note.isValidNote(trimmedNote)) {
-            throw new ParseException("Invalid note given: " + trimmedNote + "\n"
-                    + Note.MESSAGE_CONSTRAINTS);
+            throw new ParseException(makeExceptionMessage("note", trimmedNote,
+                    Note.MESSAGE_CONSTRAINTS));
         } else if (!Note.hasValidLength(trimmedNote)) {
             throw new ParseException(Note.MESSAGE_CONSTRAINTS_CHARACTER_LIMIT);
         }

--- a/src/main/java/connexion/logic/parser/ScheduleCommandParser.java
+++ b/src/main/java/connexion/logic/parser/ScheduleCommandParser.java
@@ -2,6 +2,7 @@ package connexion.logic.parser;
 
 
 import static connexion.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static connexion.logic.Messages.MESSAGE_INVALID_FIELD_FORMAT;
 import static connexion.logic.parser.CliSyntax.PREFIX_SCHEDULE;
 import static connexion.logic.parser.CliSyntax.PREFIX_SCHEDULE_NAME;
 import static java.util.Objects.requireNonNull;
@@ -10,6 +11,7 @@ import java.time.Clock;
 import java.time.LocalDateTime;
 
 import connexion.commons.core.index.Index;
+import connexion.logic.commands.DeleteCommand;
 import connexion.logic.commands.ScheduleCommand;
 import connexion.logic.commands.ScheduleCommand.ScheduleDescriptor;
 import connexion.logic.parser.exceptions.ParseException;
@@ -40,7 +42,8 @@ public class ScheduleCommandParser implements ClockDependentParser<ScheduleComma
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ScheduleCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_FIELD_FORMAT,
+                    pe.getMessage(), ScheduleCommand.MESSAGE_USAGE), pe);
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_SCHEDULE, PREFIX_SCHEDULE_NAME);

--- a/src/main/java/connexion/logic/parser/ScheduleCommandParser.java
+++ b/src/main/java/connexion/logic/parser/ScheduleCommandParser.java
@@ -11,7 +11,6 @@ import java.time.Clock;
 import java.time.LocalDateTime;
 
 import connexion.commons.core.index.Index;
-import connexion.logic.commands.DeleteCommand;
 import connexion.logic.commands.ScheduleCommand;
 import connexion.logic.commands.ScheduleCommand.ScheduleDescriptor;
 import connexion.logic.parser.exceptions.ParseException;

--- a/src/main/java/connexion/logic/parser/UnMarkCommandParser.java
+++ b/src/main/java/connexion/logic/parser/UnMarkCommandParser.java
@@ -1,10 +1,8 @@
 package connexion.logic.parser;
 
-import static connexion.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static connexion.logic.Messages.MESSAGE_INVALID_FIELD_FORMAT;
 
 import connexion.commons.core.index.Index;
-import connexion.logic.commands.DeleteCommand;
 import connexion.logic.commands.UnMarkCommand;
 import connexion.logic.parser.exceptions.ParseException;
 

--- a/src/main/java/connexion/logic/parser/UnMarkCommandParser.java
+++ b/src/main/java/connexion/logic/parser/UnMarkCommandParser.java
@@ -1,8 +1,10 @@
 package connexion.logic.parser;
 
 import static connexion.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static connexion.logic.Messages.MESSAGE_INVALID_FIELD_FORMAT;
 
 import connexion.commons.core.index.Index;
+import connexion.logic.commands.DeleteCommand;
 import connexion.logic.commands.UnMarkCommand;
 import connexion.logic.parser.exceptions.ParseException;
 
@@ -21,7 +23,7 @@ public class UnMarkCommandParser implements Parser<UnMarkCommand> {
             return new UnMarkCommand(index);
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnMarkCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_FIELD_FORMAT, pe.getMessage(), UnMarkCommand.MESSAGE_USAGE), pe);
         }
     }
 }

--- a/src/test/java/connexion/logic/commands/CommandTestUtil.java
+++ b/src/test/java/connexion/logic/commands/CommandTestUtil.java
@@ -60,6 +60,32 @@ public class CommandTestUtil {
     // Empty String is valid too
     public static final String VALID_NOTE_BOB = "";
 
+    public static final String INVALID_NAME = "James&"; // '&' not allowed in names
+    public static final String INVALID_PHONE = "911a"; // 'a' not allowed in phones
+    public static final String INVALID_EMAIL ="bob!yahoo"; // missing '@' symbol
+    public static final String INVALID_COMPANY = ""; // empty string not allowed for companies
+    public static final String INVALID_JOB = ""; // empty string not allowed for jobs
+    public static final String INVALID_TAG = "hubby*"; // '*' not allowed in tags
+    public static final String INVALID_SCHEDULE = "2023/07/10/06/59"; // '/' not allowed for schedule
+    public static final String INVALID_SCHEDULE_DATE = "2023-40-10-06-59"; // correct format but wrong date (month field is wrong)
+    public static final String INVALID_SCHEDULE_NAME = "Meeting*"; // '*' not allowed in schedule names
+
+    public static final String INVALID_NOTE = "\u2063"; // invisible characters not allowed for note
+
+    public static final String NOTE_WITH_INVALID_LENGTH =
+            "One morning, when Gregor Samsa woke from troubled dreams, "
+            + "he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, "
+            + "and if he lifted his head a little he could see his brown belly, slightly domed and divided by "
+            + "arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off "
+            + "any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about "
+            + "helplessly as he looked. \"What's happened to me?\" he thought. It wasn't a dream. His room, "
+            + "a proper human room although a little too small, lay peacefully between its four familiar walls. "
+            + "A collection of textile samples lay spread out on the table - Samsa was a travelling salesman - and "
+            + "above it there hung a picture that he had recently cut out of an illustrated magazine and housed in "
+            + "a nice, gilded frame. It showed a lady fitted out with a fur hat and fur boa who sat upright, "
+            + "raising a heavy fur muff that covered the whole of her lower arm towards ta"; // exceeds character limit
+
+
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
     public static final String PHONE_DESC_AMY = " " + PREFIX_PHONE + VALID_PHONE_AMY;
@@ -80,34 +106,19 @@ public class CommandTestUtil {
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
 
-    public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
-    public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
-    public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
-    public static final String INVALID_COMPANY_DESC = " " + PREFIX_COMPANY; // empty string not allowed for companies
-    public static final String INVALID_JOB_DESC = " " + PREFIX_JOB; // empty string not allowed for jobs
-    public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
-    public static final String INVALID_SCHEDULE_DESC = " " + PREFIX_SCHEDULE
-            + "2023/07/10/06/59"; // '/' not allowed for schedule
-    public static final String INVALID_SCHEDULE_DATE = " " + PREFIX_SCHEDULE
-            + "2023-40-10-06-59"; // correct format but wrong date (month field is wrong)
-    public static final String INVALID_SCHEDULE_NAME_DESC = " "
-            + PREFIX_SCHEDULE_NAME + "Meeting*"; // '*' not allowed in schedule names
+    public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + INVALID_NAME;
+    public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + INVALID_PHONE;
+    public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + INVALID_EMAIL;
+    public static final String INVALID_COMPANY_DESC = " " + PREFIX_COMPANY + INVALID_COMPANY;
+    public static final String INVALID_JOB_DESC = " " + PREFIX_JOB + INVALID_JOB;
+    public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + INVALID_TAG;
+    public static final String INVALID_SCHEDULE_DESC = " " + PREFIX_SCHEDULE + INVALID_SCHEDULE;
+    public static final String INVALID_SCHEDULE_DATE_DESC = " " + PREFIX_SCHEDULE + INVALID_SCHEDULE_DATE;
+    public static final String INVALID_SCHEDULE_NAME_DESC = " " + PREFIX_SCHEDULE_NAME + INVALID_SCHEDULE_NAME;
 
-    public static final String INVALID_NOTE_DESC = " " + PREFIX_NOTE
-            + "\u2063"; // invisible characters not allowed for note
+    public static final String INVALID_NOTE_DESC = " " + PREFIX_NOTE + INVALID_NOTE;
 
-    public static final String NOTE_WITH_INVALID_LENGTH_DESC = " " + PREFIX_NOTE
-            + "One morning, when Gregor Samsa woke from troubled dreams, "
-            + "he found himself transformed in his bed into a horrible vermin. He lay on his armour-like back, "
-            + "and if he lifted his head a little he could see his brown belly, slightly domed and divided by "
-            + "arches into stiff sections. The bedding was hardly able to cover it and seemed ready to slide off "
-            + "any moment. His many legs, pitifully thin compared with the size of the rest of him, waved about "
-            + "helplessly as he looked. \"What's happened to me?\" he thought. It wasn't a dream. His room, "
-            + "a proper human room although a little too small, lay peacefully between its four familiar walls. "
-            + "A collection of textile samples lay spread out on the table - Samsa was a travelling salesman - and "
-            + "above it there hung a picture that he had recently cut out of an illustrated magazine and housed in "
-            + "a nice, gilded frame. It showed a lady fitted out with a fur hat and fur boa who sat upright, "
-            + "raising a heavy fur muff that covered the whole of her lower arm towards ta"; // exceeds character limit
+    public static final String NOTE_WITH_INVALID_LENGTH_DESC = " " + PREFIX_NOTE + NOTE_WITH_INVALID_LENGTH;
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
 

--- a/src/test/java/connexion/logic/commands/CommandTestUtil.java
+++ b/src/test/java/connexion/logic/commands/CommandTestUtil.java
@@ -62,12 +62,13 @@ public class CommandTestUtil {
 
     public static final String INVALID_NAME = "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE = "911a"; // 'a' not allowed in phones
-    public static final String INVALID_EMAIL ="bob!yahoo"; // missing '@' symbol
+    public static final String INVALID_EMAIL = "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_COMPANY = ""; // empty string not allowed for companies
     public static final String INVALID_JOB = ""; // empty string not allowed for jobs
     public static final String INVALID_TAG = "hubby*"; // '*' not allowed in tags
     public static final String INVALID_SCHEDULE = "2023/07/10/06/59"; // '/' not allowed for schedule
-    public static final String INVALID_SCHEDULE_DATE = "2023-40-10-06-59"; // correct format but wrong date (month field is wrong)
+    public static final String INVALID_SCHEDULE_DATE = "2023-40-10-06-59";
+    // correct format but wrong date (month field is wrong)
     public static final String INVALID_SCHEDULE_NAME = "Meeting*"; // '*' not allowed in schedule names
 
     public static final String INVALID_NOTE = "\u2063"; // invisible characters not allowed for note

--- a/src/test/java/connexion/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/connexion/logic/parser/AddCommandParserTest.java
@@ -5,11 +5,17 @@ import static connexion.logic.commands.CommandTestUtil.COMPANY_DESC_AMY;
 import static connexion.logic.commands.CommandTestUtil.COMPANY_DESC_BOB;
 import static connexion.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static connexion.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
+import static connexion.logic.commands.CommandTestUtil.INVALID_COMPANY;
 import static connexion.logic.commands.CommandTestUtil.INVALID_COMPANY_DESC;
+import static connexion.logic.commands.CommandTestUtil.INVALID_EMAIL;
 import static connexion.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
+import static connexion.logic.commands.CommandTestUtil.INVALID_JOB;
 import static connexion.logic.commands.CommandTestUtil.INVALID_JOB_DESC;
+import static connexion.logic.commands.CommandTestUtil.INVALID_NAME;
 import static connexion.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
+import static connexion.logic.commands.CommandTestUtil.INVALID_PHONE;
 import static connexion.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
+import static connexion.logic.commands.CommandTestUtil.INVALID_TAG;
 import static connexion.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static connexion.logic.commands.CommandTestUtil.JOB_DESC_AMY;
 import static connexion.logic.commands.CommandTestUtil.JOB_DESC_BOB;
@@ -33,6 +39,7 @@ import static connexion.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static connexion.logic.parser.CliSyntax.PREFIX_JOB;
 import static connexion.logic.parser.CliSyntax.PREFIX_NAME;
 import static connexion.logic.parser.CliSyntax.PREFIX_PHONE;
+import static connexion.logic.parser.CliSyntax.PREFIX_TAG;
 import static connexion.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static connexion.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static connexion.testutil.ClockUtil.DEFAULT_TEST_CLOCK;
@@ -187,32 +194,39 @@ public class AddCommandParserTest {
         // invalid name
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB
                 + EMAIL_DESC_BOB + COMPANY_DESC_BOB + JOB_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                "Invalid name given: " + INVALID_NAME + "\n" + Name.MESSAGE_CONSTRAINTS);
 
         // invalid phone
         assertParseFailure(parser, NAME_DESC_BOB + INVALID_PHONE_DESC
                 + EMAIL_DESC_BOB + COMPANY_DESC_BOB + JOB_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Phone.MESSAGE_CONSTRAINTS);
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                "Invalid phone number given: " + INVALID_PHONE + "\n" + Phone.MESSAGE_CONSTRAINTS);
 
         // invalid email
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_EMAIL_DESC
-                + COMPANY_DESC_BOB + JOB_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Email.MESSAGE_CONSTRAINTS);
+                + COMPANY_DESC_BOB + JOB_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                "Invalid email given: " + INVALID_EMAIL + "\n" + Email.MESSAGE_CONSTRAINTS);
 
         // invalid company
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_COMPANY_DESC
-                + JOB_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Company.MESSAGE_CONSTRAINTS);
+                + JOB_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                "Invalid company name given: " + INVALID_COMPANY + "\n" + Company.MESSAGE_CONSTRAINTS);
 
         // invalid job
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + COMPANY_DESC_BOB + INVALID_JOB_DESC + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Job.MESSAGE_CONSTRAINTS);
+                + COMPANY_DESC_BOB + INVALID_JOB_DESC + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                "Invalid job given: " + INVALID_JOB + "\n" + Job.MESSAGE_CONSTRAINTS);
 
         // invalid tag
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + COMPANY_DESC_BOB + JOB_DESC_BOB + INVALID_TAG_DESC + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
+                + COMPANY_DESC_BOB + JOB_DESC_BOB + INVALID_TAG_DESC + TAG_DESC_FRIEND,
+                "Invalid tag given: " + INVALID_TAG  + "\n" + Tag.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                        + INVALID_COMPANY_DESC + JOB_DESC_BOB, Name.MESSAGE_CONSTRAINTS);
+                        + INVALID_COMPANY_DESC + JOB_DESC_BOB,
+                "Invalid name given: " + INVALID_NAME + "\n" +  Name.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB

--- a/src/test/java/connexion/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/connexion/logic/parser/AddCommandParserTest.java
@@ -39,7 +39,6 @@ import static connexion.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static connexion.logic.parser.CliSyntax.PREFIX_JOB;
 import static connexion.logic.parser.CliSyntax.PREFIX_NAME;
 import static connexion.logic.parser.CliSyntax.PREFIX_PHONE;
-import static connexion.logic.parser.CliSyntax.PREFIX_TAG;
 import static connexion.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static connexion.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static connexion.testutil.ClockUtil.DEFAULT_TEST_CLOCK;
@@ -221,12 +220,12 @@ public class AddCommandParserTest {
         // invalid tag
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                 + COMPANY_DESC_BOB + JOB_DESC_BOB + INVALID_TAG_DESC + TAG_DESC_FRIEND,
-                "Invalid tag given: " + INVALID_TAG  + "\n" + Tag.MESSAGE_CONSTRAINTS);
+                "Invalid tag given: " + INVALID_TAG + "\n" + Tag.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB
                         + INVALID_COMPANY_DESC + JOB_DESC_BOB,
-                "Invalid name given: " + INVALID_NAME + "\n" +  Name.MESSAGE_CONSTRAINTS);
+                "Invalid name given: " + INVALID_NAME + "\n" + Name.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB

--- a/src/test/java/connexion/logic/parser/ClearScheduleCommandParserTest.java
+++ b/src/test/java/connexion/logic/parser/ClearScheduleCommandParserTest.java
@@ -1,8 +1,6 @@
 package connexion.logic.parser;
 
 
-
-
 import static connexion.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static connexion.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static connexion.logic.parser.CommandParserTestUtil.assertParseSuccess;

--- a/src/test/java/connexion/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/connexion/logic/parser/DeleteCommandParserTest.java
@@ -1,12 +1,10 @@
 package connexion.logic.parser;
 
-import static connexion.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static connexion.logic.Messages.MESSAGE_INVALID_FIELD_FORMAT;
 import static connexion.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static connexion.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static connexion.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
-import connexion.commons.core.index.Index;
 import org.junit.jupiter.api.Test;
 
 import connexion.logic.commands.DeleteCommand;

--- a/src/test/java/connexion/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/connexion/logic/parser/DeleteCommandParserTest.java
@@ -1,10 +1,12 @@
 package connexion.logic.parser;
 
 import static connexion.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static connexion.logic.Messages.MESSAGE_INVALID_FIELD_FORMAT;
 import static connexion.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static connexion.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static connexion.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
+import connexion.commons.core.index.Index;
 import org.junit.jupiter.api.Test;
 
 import connexion.logic.commands.DeleteCommand;
@@ -27,6 +29,9 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a", String.format(
+                MESSAGE_INVALID_FIELD_FORMAT,
+                ParserUtilTest.makeExceptionMessage("index", "a", ParserUtil.MESSAGE_INVALID_INDEX),
+                DeleteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/connexion/logic/parser/DetailCommandParserTest.java
+++ b/src/test/java/connexion/logic/parser/DetailCommandParserTest.java
@@ -1,13 +1,10 @@
 package connexion.logic.parser;
 
-import static connexion.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static connexion.logic.Messages.MESSAGE_INVALID_FIELD_FORMAT;
 import static connexion.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static connexion.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static connexion.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
-import connexion.commons.core.index.Index;
-import connexion.logic.commands.DeleteCommand;
 import org.junit.jupiter.api.Test;
 
 import connexion.logic.commands.DetailCommand;

--- a/src/test/java/connexion/logic/parser/DetailCommandParserTest.java
+++ b/src/test/java/connexion/logic/parser/DetailCommandParserTest.java
@@ -1,10 +1,13 @@
 package connexion.logic.parser;
 
 import static connexion.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static connexion.logic.Messages.MESSAGE_INVALID_FIELD_FORMAT;
 import static connexion.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static connexion.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static connexion.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
+import connexion.commons.core.index.Index;
+import connexion.logic.commands.DeleteCommand;
 import org.junit.jupiter.api.Test;
 
 import connexion.logic.commands.DetailCommand;
@@ -20,6 +23,9 @@ public class DetailCommandParserTest {
     @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DetailCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_INVALID_FIELD_FORMAT,
+                        ParserUtilTest.makeExceptionMessage("index", "a",
+                                ParserUtil.MESSAGE_INVALID_INDEX),
+                        DetailCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/connexion/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/connexion/logic/parser/EditCommandParserTest.java
@@ -1,6 +1,7 @@
 package connexion.logic.parser;
 
 import static connexion.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static connexion.logic.Messages.MESSAGE_INVALID_FIELD_FORMAT;
 import static connexion.logic.commands.CommandTestUtil.COMPANY_DESC_AMY;
 import static connexion.logic.commands.CommandTestUtil.COMPANY_DESC_BOB;
 import static connexion.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
@@ -44,6 +45,7 @@ import static connexion.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static connexion.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static connexion.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
 
+import connexion.logic.commands.DeleteCommand;
 import org.junit.jupiter.api.Test;
 
 import connexion.commons.core.index.Index;
@@ -70,28 +72,48 @@ public class EditCommandParserTest {
     @Test
     public void parse_missingParts_failure() {
         // no index specified
-        assertParseFailure(parser, VALID_NAME_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, VALID_NAME_AMY, String.format(MESSAGE_INVALID_FIELD_FORMAT,
+                ParserUtilTest.makeExceptionMessage("index",VALID_NAME_AMY, ParserUtil.MESSAGE_INVALID_INDEX),
+                EditCommand.MESSAGE_USAGE));
 
         // no field specified
         assertParseFailure(parser, "1", EditCommand.MESSAGE_NOT_EDITED);
 
         // no index and no field specified
-        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_FIELD_FORMAT,
+                ParserUtilTest.makeExceptionMessage("index","", ParserUtil.MESSAGE_INVALID_INDEX),
+                EditCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_invalidPreamble_failure() {
         // negative index
-        assertParseFailure(parser, "-5" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "-5" + NAME_DESC_AMY,
+                String.format(MESSAGE_INVALID_FIELD_FORMAT,
+                        ParserUtilTest.makeExceptionMessage("index",
+                                "-5" , ParserUtil.MESSAGE_INVALID_INDEX),
+                        EditCommand.MESSAGE_USAGE));
 
         // zero index
-        assertParseFailure(parser, "0" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "0" + NAME_DESC_AMY,
+                String.format(MESSAGE_INVALID_FIELD_FORMAT,
+                        ParserUtilTest.makeExceptionMessage("index",
+                                "0" , ParserUtil.MESSAGE_INVALID_INDEX),
+                        EditCommand.MESSAGE_USAGE));
 
         // invalid arguments being parsed as preamble
-        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1 some random string" + NAME_DESC_AMY,
+                String.format(MESSAGE_INVALID_FIELD_FORMAT,
+                        ParserUtilTest.makeExceptionMessage("index",
+                                "1 some random string" , ParserUtil.MESSAGE_INVALID_INDEX),
+                        EditCommand.MESSAGE_USAGE));
 
         // invalid prefix being parsed as preamble
-        assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1 i/ string" + NAME_DESC_AMY,
+                String.format(MESSAGE_INVALID_FIELD_FORMAT,
+                        ParserUtilTest.makeExceptionMessage("index",
+                                "1 i/ string" , ParserUtil.MESSAGE_INVALID_INDEX),
+                        EditCommand.MESSAGE_USAGE));
     }
 
     @Test

--- a/src/test/java/connexion/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/connexion/logic/parser/EditCommandParserTest.java
@@ -39,6 +39,7 @@ import static connexion.logic.parser.CliSyntax.PREFIX_PHONE;
 import static connexion.logic.parser.CliSyntax.PREFIX_TAG;
 import static connexion.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static connexion.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static connexion.logic.parser.ParserUtilTest.makeExceptionMessage;
 import static connexion.testutil.ClockUtil.DEFAULT_TEST_CLOCK;
 import static connexion.testutil.ClockUtil.DEFAULT_TEST_TIME;
 import static connexion.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -72,7 +73,7 @@ public class EditCommandParserTest {
     public void parse_missingParts_failure() {
         // no index specified
         assertParseFailure(parser, VALID_NAME_AMY, String.format(MESSAGE_INVALID_FIELD_FORMAT,
-                ParserUtilTest.makeExceptionMessage("index", VALID_NAME_AMY, ParserUtil.MESSAGE_INVALID_INDEX),
+                makeExceptionMessage("index", VALID_NAME_AMY, ParserUtil.MESSAGE_INVALID_INDEX),
                 EditCommand.MESSAGE_USAGE));
 
         // no field specified
@@ -80,7 +81,7 @@ public class EditCommandParserTest {
 
         // no index and no field specified
         assertParseFailure(parser, "", String.format(MESSAGE_INVALID_FIELD_FORMAT,
-                ParserUtilTest.makeExceptionMessage("index", "", ParserUtil.MESSAGE_INVALID_INDEX),
+                makeExceptionMessage("index", "", ParserUtil.MESSAGE_INVALID_INDEX),
                 EditCommand.MESSAGE_USAGE));
     }
 
@@ -89,28 +90,28 @@ public class EditCommandParserTest {
         // negative index
         assertParseFailure(parser, "-5" + NAME_DESC_AMY,
                 String.format(MESSAGE_INVALID_FIELD_FORMAT,
-                        ParserUtilTest.makeExceptionMessage("index",
+                        makeExceptionMessage("index",
                                 "-5" , ParserUtil.MESSAGE_INVALID_INDEX),
                         EditCommand.MESSAGE_USAGE));
 
         // zero index
         assertParseFailure(parser, "0" + NAME_DESC_AMY,
                 String.format(MESSAGE_INVALID_FIELD_FORMAT,
-                        ParserUtilTest.makeExceptionMessage("index",
+                        makeExceptionMessage("index",
                                 "0" , ParserUtil.MESSAGE_INVALID_INDEX),
                         EditCommand.MESSAGE_USAGE));
 
         // invalid arguments being parsed as preamble
         assertParseFailure(parser, "1 some random string" + NAME_DESC_AMY,
                 String.format(MESSAGE_INVALID_FIELD_FORMAT,
-                        ParserUtilTest.makeExceptionMessage("index",
+                        makeExceptionMessage("index",
                                 "1 some random string" , ParserUtil.MESSAGE_INVALID_INDEX),
                         EditCommand.MESSAGE_USAGE));
 
         // invalid prefix being parsed as preamble
         assertParseFailure(parser, "1 i/ string" + NAME_DESC_AMY,
                 String.format(MESSAGE_INVALID_FIELD_FORMAT,
-                        ParserUtilTest.makeExceptionMessage("index",
+                        makeExceptionMessage("index",
                                 "1 i/ string" , ParserUtil.MESSAGE_INVALID_INDEX),
                         EditCommand.MESSAGE_USAGE));
     }
@@ -118,40 +119,41 @@ public class EditCommandParserTest {
     @Test
     public void parse_invalidValue_failure() {
         assertParseFailure(parser, "1" + INVALID_NAME_DESC,
-                "Invalid name given: " + INVALID_NAME + "\n" + Name.MESSAGE_CONSTRAINTS);
+                makeExceptionMessage("name", INVALID_NAME, Name.MESSAGE_CONSTRAINTS));
         // invalid name
         assertParseFailure(parser, "1" + INVALID_PHONE_DESC,
-                "Invalid phone number given: " + INVALID_PHONE + "\n" + Phone.MESSAGE_CONSTRAINTS);
+                makeExceptionMessage("phone number", INVALID_PHONE, Phone.MESSAGE_CONSTRAINTS));
         // invalid phone
         assertParseFailure(parser, "1" + INVALID_EMAIL_DESC,
-                "Invalid email given: " + INVALID_EMAIL + "\n" + Email.MESSAGE_CONSTRAINTS);
+                makeExceptionMessage("email", INVALID_EMAIL, Email.MESSAGE_CONSTRAINTS));
         // invalid email
         assertParseFailure(parser, "1" + INVALID_COMPANY_DESC,
-                "Invalid company name given: " + INVALID_COMPANY + "\n" + Company.MESSAGE_CONSTRAINTS);
+                makeExceptionMessage("company name", INVALID_COMPANY, Company.MESSAGE_CONSTRAINTS));
         // invalid company
         assertParseFailure(parser, "1" + INVALID_JOB_DESC,
-                "Invalid job given: " + INVALID_JOB + "\n" + Job.MESSAGE_CONSTRAINTS);
+                makeExceptionMessage("job", INVALID_JOB, Job.MESSAGE_CONSTRAINTS));
         // invalid job
         assertParseFailure(parser, "1" + INVALID_TAG_DESC,
-                "Invalid tag given: " + INVALID_TAG + "\n" + Tag.MESSAGE_CONSTRAINTS); // invalid tag
+                makeExceptionMessage("tag", INVALID_TAG, Tag.MESSAGE_CONSTRAINTS));
+        // invalid tag
 
         // invalid phone followed by valid email
         assertParseFailure(parser, "1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY,
-                "Invalid phone number given: " + INVALID_PHONE + "\n" + Phone.MESSAGE_CONSTRAINTS);
+                makeExceptionMessage("phone number", INVALID_PHONE, Phone.MESSAGE_CONSTRAINTS));
 
         // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Person} being edited,
         // parsing it together with a valid tag results in error
         assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY,
-                "Invalid tag given: " + "" + "\n" + Tag.MESSAGE_CONSTRAINTS);
+                makeExceptionMessage("tag", "", Tag.MESSAGE_CONSTRAINTS));
         assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND,
-                "Invalid tag given: " + "" + "\n" + Tag.MESSAGE_CONSTRAINTS);
+                makeExceptionMessage("tag", "", Tag.MESSAGE_CONSTRAINTS));
         assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND,
-                "Invalid tag given: " + "" + "\n" + Tag.MESSAGE_CONSTRAINTS);
+                makeExceptionMessage("tag", "", Tag.MESSAGE_CONSTRAINTS));
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC
                         + VALID_COMPANY_AMY + VALID_JOB_AMY + VALID_PHONE_AMY,
-                        "Invalid name given: " + INVALID_NAME + "\n" + Name.MESSAGE_CONSTRAINTS);
+                        makeExceptionMessage("name", INVALID_NAME, Name.MESSAGE_CONSTRAINTS));
     }
 
     @Test

--- a/src/test/java/connexion/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/connexion/logic/parser/EditCommandParserTest.java
@@ -45,7 +45,6 @@ import static connexion.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static connexion.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static connexion.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
 
-import connexion.logic.commands.DeleteCommand;
 import org.junit.jupiter.api.Test;
 
 import connexion.commons.core.index.Index;
@@ -73,7 +72,7 @@ public class EditCommandParserTest {
     public void parse_missingParts_failure() {
         // no index specified
         assertParseFailure(parser, VALID_NAME_AMY, String.format(MESSAGE_INVALID_FIELD_FORMAT,
-                ParserUtilTest.makeExceptionMessage("index",VALID_NAME_AMY, ParserUtil.MESSAGE_INVALID_INDEX),
+                ParserUtilTest.makeExceptionMessage("index", VALID_NAME_AMY, ParserUtil.MESSAGE_INVALID_INDEX),
                 EditCommand.MESSAGE_USAGE));
 
         // no field specified
@@ -81,7 +80,7 @@ public class EditCommandParserTest {
 
         // no index and no field specified
         assertParseFailure(parser, "", String.format(MESSAGE_INVALID_FIELD_FORMAT,
-                ParserUtilTest.makeExceptionMessage("index","", ParserUtil.MESSAGE_INVALID_INDEX),
+                ParserUtilTest.makeExceptionMessage("index", "", ParserUtil.MESSAGE_INVALID_INDEX),
                 EditCommand.MESSAGE_USAGE));
     }
 

--- a/src/test/java/connexion/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/connexion/logic/parser/EditCommandParserTest.java
@@ -5,11 +5,17 @@ import static connexion.logic.commands.CommandTestUtil.COMPANY_DESC_AMY;
 import static connexion.logic.commands.CommandTestUtil.COMPANY_DESC_BOB;
 import static connexion.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static connexion.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
+import static connexion.logic.commands.CommandTestUtil.INVALID_COMPANY;
 import static connexion.logic.commands.CommandTestUtil.INVALID_COMPANY_DESC;
+import static connexion.logic.commands.CommandTestUtil.INVALID_EMAIL;
 import static connexion.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
+import static connexion.logic.commands.CommandTestUtil.INVALID_JOB;
 import static connexion.logic.commands.CommandTestUtil.INVALID_JOB_DESC;
+import static connexion.logic.commands.CommandTestUtil.INVALID_NAME;
 import static connexion.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
+import static connexion.logic.commands.CommandTestUtil.INVALID_PHONE;
 import static connexion.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
+import static connexion.logic.commands.CommandTestUtil.INVALID_TAG;
 import static connexion.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static connexion.logic.commands.CommandTestUtil.JOB_DESC_AMY;
 import static connexion.logic.commands.CommandTestUtil.NAME_DESC_AMY;
@@ -90,26 +96,41 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_invalidValue_failure() {
-        assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
-        assertParseFailure(parser, "1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
-        assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
-        assertParseFailure(parser, "1" + INVALID_COMPANY_DESC, Company.MESSAGE_CONSTRAINTS); // invalid company
-        assertParseFailure(parser, "1" + INVALID_JOB_DESC, Job.MESSAGE_CONSTRAINTS); // invalid job
-        assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
+        assertParseFailure(parser, "1" + INVALID_NAME_DESC,
+                "Invalid name given: " + INVALID_NAME + "\n" + Name.MESSAGE_CONSTRAINTS);
+        // invalid name
+        assertParseFailure(parser, "1" + INVALID_PHONE_DESC,
+                "Invalid phone number given: " + INVALID_PHONE + "\n" + Phone.MESSAGE_CONSTRAINTS);
+        // invalid phone
+        assertParseFailure(parser, "1" + INVALID_EMAIL_DESC,
+                "Invalid email given: " + INVALID_EMAIL + "\n" + Email.MESSAGE_CONSTRAINTS);
+        // invalid email
+        assertParseFailure(parser, "1" + INVALID_COMPANY_DESC,
+                "Invalid company name given: " + INVALID_COMPANY + "\n" + Company.MESSAGE_CONSTRAINTS);
+        // invalid company
+        assertParseFailure(parser, "1" + INVALID_JOB_DESC,
+                "Invalid job given: " + INVALID_JOB + "\n" + Job.MESSAGE_CONSTRAINTS);
+        // invalid job
+        assertParseFailure(parser, "1" + INVALID_TAG_DESC,
+                "Invalid tag given: " + INVALID_TAG + "\n" + Tag.MESSAGE_CONSTRAINTS); // invalid tag
 
         // invalid phone followed by valid email
-        assertParseFailure(parser, "1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY,
+                "Invalid phone number given: " + INVALID_PHONE + "\n" + Phone.MESSAGE_CONSTRAINTS);
 
         // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Person} being edited,
         // parsing it together with a valid tag results in error
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY,
+                "Invalid tag given: " + "" + "\n" + Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND,
+                "Invalid tag given: " + "" + "\n" + Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND,
+                "Invalid tag given: " + "" + "\n" + Tag.MESSAGE_CONSTRAINTS);
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC
                         + VALID_COMPANY_AMY + VALID_JOB_AMY + VALID_PHONE_AMY,
-                        Name.MESSAGE_CONSTRAINTS);
+                        "Invalid name given: " + INVALID_NAME + "\n" + Name.MESSAGE_CONSTRAINTS);
     }
 
     @Test

--- a/src/test/java/connexion/logic/parser/MarkCommandParserTest.java
+++ b/src/test/java/connexion/logic/parser/MarkCommandParserTest.java
@@ -1,13 +1,10 @@
 package connexion.logic.parser;
 
-import static connexion.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static connexion.logic.Messages.MESSAGE_INVALID_FIELD_FORMAT;
-import static connexion.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static connexion.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static connexion.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static connexion.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
-import connexion.logic.commands.EditCommand;
 import org.junit.jupiter.api.Test;
 
 import connexion.logic.commands.MarkCommand;

--- a/src/test/java/connexion/logic/parser/MarkCommandParserTest.java
+++ b/src/test/java/connexion/logic/parser/MarkCommandParserTest.java
@@ -1,10 +1,13 @@
 package connexion.logic.parser;
 
 import static connexion.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static connexion.logic.Messages.MESSAGE_INVALID_FIELD_FORMAT;
+import static connexion.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static connexion.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static connexion.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static connexion.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
+import connexion.logic.commands.EditCommand;
 import org.junit.jupiter.api.Test;
 
 import connexion.logic.commands.MarkCommand;
@@ -14,7 +17,12 @@ public class MarkCommandParserTest {
     private MarkCommandParser parser = new MarkCommandParser();
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "      " ,
+                String.format(MESSAGE_INVALID_FIELD_FORMAT,
+                        ParserUtilTest.makeExceptionMessage("index",
+                                "      ".trim() , ParserUtil.MESSAGE_INVALID_INDEX),
+                        MarkCommand.MESSAGE_USAGE));
+
     }
 
     @Test
@@ -24,7 +32,11 @@ public class MarkCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a",
+                String.format(MESSAGE_INVALID_FIELD_FORMAT,
+                        ParserUtilTest.makeExceptionMessage("index",
+                                "a" , ParserUtil.MESSAGE_INVALID_INDEX),
+                        MarkCommand.MESSAGE_USAGE));
     }
 
 }

--- a/src/test/java/connexion/logic/parser/NoteCommandParserTest.java
+++ b/src/test/java/connexion/logic/parser/NoteCommandParserTest.java
@@ -1,8 +1,10 @@
 package connexion.logic.parser;
 
 import static connexion.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static connexion.logic.Messages.MESSAGE_INVALID_FIELD_FORMAT;
 import static connexion.logic.commands.CommandTestUtil.INVALID_NOTE;
 import static connexion.logic.commands.CommandTestUtil.INVALID_NOTE_DESC;
+import static connexion.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static connexion.logic.commands.CommandTestUtil.NOTE_DESC_AMY;
 import static connexion.logic.commands.CommandTestUtil.NOTE_DESC_BOB;
 import static connexion.logic.commands.CommandTestUtil.NOTE_WITH_INVALID_LENGTH_DESC;
@@ -14,6 +16,7 @@ import static connexion.testutil.ClockUtil.DEFAULT_TEST_CLOCK;
 import static connexion.testutil.ClockUtil.DEFAULT_TEST_TIME;
 import static connexion.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 
+import connexion.logic.commands.MarkCommand;
 import org.junit.jupiter.api.Test;
 
 import connexion.commons.core.index.Index;
@@ -32,28 +35,53 @@ public class NoteCommandParserTest {
     @Test
     public void parse_missingParts_failure() {
         // no index specified
-        assertParseFailure(parser, VALID_NOTE_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, VALID_NOTE_AMY,
+                String.format(MESSAGE_INVALID_FIELD_FORMAT,
+                        ParserUtilTest.makeExceptionMessage("index",
+                                VALID_NOTE_AMY , ParserUtil.MESSAGE_INVALID_INDEX),
+                        NoteCommand.MESSAGE_USAGE));
 
         // no field specified
         assertParseFailure(parser, "1", MESSAGE_INVALID_FORMAT);
 
         // no index and no field specified
-        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+        // no index specified
+        assertParseFailure(parser, "",
+                String.format(MESSAGE_INVALID_FIELD_FORMAT,
+                        ParserUtilTest.makeExceptionMessage("index",
+                                "" , ParserUtil.MESSAGE_INVALID_INDEX),
+                        NoteCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_invalidPreamble_failure() {
         // negative index
-        assertParseFailure(parser, "-5" + NOTE_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "-5",
+                String.format(MESSAGE_INVALID_FIELD_FORMAT,
+                        ParserUtilTest.makeExceptionMessage("index",
+                                "-5" , ParserUtil.MESSAGE_INVALID_INDEX),
+                        NoteCommand.MESSAGE_USAGE));
 
         // zero index
-        assertParseFailure(parser, "0" + NOTE_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "0",
+                String.format(MESSAGE_INVALID_FIELD_FORMAT,
+                        ParserUtilTest.makeExceptionMessage("index",
+                                "0" , ParserUtil.MESSAGE_INVALID_INDEX),
+                        NoteCommand.MESSAGE_USAGE));
 
         // invalid arguments being parsed as preamble
-        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1 some random string",
+                String.format(MESSAGE_INVALID_FIELD_FORMAT,
+                        ParserUtilTest.makeExceptionMessage("index",
+                                "1 some random string" , ParserUtil.MESSAGE_INVALID_INDEX),
+                        NoteCommand.MESSAGE_USAGE));
 
         // invalid prefix being parsed as preamble
-        assertParseFailure(parser, "1 e/ string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1 e/ string",
+                String.format(MESSAGE_INVALID_FIELD_FORMAT,
+                        ParserUtilTest.makeExceptionMessage("index",
+                                "1 e/ string" , ParserUtil.MESSAGE_INVALID_INDEX),
+                        NoteCommand.MESSAGE_USAGE));
     }
 
     @Test

--- a/src/test/java/connexion/logic/parser/NoteCommandParserTest.java
+++ b/src/test/java/connexion/logic/parser/NoteCommandParserTest.java
@@ -1,9 +1,11 @@
 package connexion.logic.parser;
 
 import static connexion.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static connexion.logic.commands.CommandTestUtil.INVALID_NOTE;
 import static connexion.logic.commands.CommandTestUtil.INVALID_NOTE_DESC;
 import static connexion.logic.commands.CommandTestUtil.NOTE_DESC_AMY;
 import static connexion.logic.commands.CommandTestUtil.NOTE_DESC_BOB;
+import static connexion.logic.commands.CommandTestUtil.NOTE_WITH_INVALID_LENGTH;
 import static connexion.logic.commands.CommandTestUtil.NOTE_WITH_INVALID_LENGTH_DESC;
 import static connexion.logic.commands.CommandTestUtil.VALID_NOTE_AMY;
 import static connexion.logic.commands.CommandTestUtil.VALID_NOTE_BOB;
@@ -57,9 +59,10 @@ public class NoteCommandParserTest {
 
     @Test
     public void parse_invalidValueOrInvalidLength_failure() {
-        assertParseFailure(parser, "1" + INVALID_NOTE_DESC, Note.MESSAGE_CONSTRAINTS); // invalid note
+        assertParseFailure(parser, "1" + INVALID_NOTE_DESC,
+                "Invalid note given: " + INVALID_NOTE + "\n" + Note.MESSAGE_CONSTRAINTS); // invalid note
         assertParseFailure(parser, "1" + NOTE_WITH_INVALID_LENGTH_DESC,
-                Note.MESSAGE_CONSTRAINTS_CHARACTER_LIMIT); // note with invalid length
+                 Note.MESSAGE_CONSTRAINTS_CHARACTER_LIMIT); // note with invalid length
     }
 
     @Test

--- a/src/test/java/connexion/logic/parser/NoteCommandParserTest.java
+++ b/src/test/java/connexion/logic/parser/NoteCommandParserTest.java
@@ -4,8 +4,6 @@ import static connexion.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static connexion.logic.Messages.MESSAGE_INVALID_FIELD_FORMAT;
 import static connexion.logic.commands.CommandTestUtil.INVALID_NOTE;
 import static connexion.logic.commands.CommandTestUtil.INVALID_NOTE_DESC;
-import static connexion.logic.commands.CommandTestUtil.NAME_DESC_AMY;
-import static connexion.logic.commands.CommandTestUtil.NOTE_DESC_AMY;
 import static connexion.logic.commands.CommandTestUtil.NOTE_DESC_BOB;
 import static connexion.logic.commands.CommandTestUtil.NOTE_WITH_INVALID_LENGTH_DESC;
 import static connexion.logic.commands.CommandTestUtil.VALID_NOTE_AMY;
@@ -16,7 +14,6 @@ import static connexion.testutil.ClockUtil.DEFAULT_TEST_CLOCK;
 import static connexion.testutil.ClockUtil.DEFAULT_TEST_TIME;
 import static connexion.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 
-import connexion.logic.commands.MarkCommand;
 import org.junit.jupiter.api.Test;
 
 import connexion.commons.core.index.Index;

--- a/src/test/java/connexion/logic/parser/NoteCommandParserTest.java
+++ b/src/test/java/connexion/logic/parser/NoteCommandParserTest.java
@@ -5,7 +5,6 @@ import static connexion.logic.commands.CommandTestUtil.INVALID_NOTE;
 import static connexion.logic.commands.CommandTestUtil.INVALID_NOTE_DESC;
 import static connexion.logic.commands.CommandTestUtil.NOTE_DESC_AMY;
 import static connexion.logic.commands.CommandTestUtil.NOTE_DESC_BOB;
-import static connexion.logic.commands.CommandTestUtil.NOTE_WITH_INVALID_LENGTH;
 import static connexion.logic.commands.CommandTestUtil.NOTE_WITH_INVALID_LENGTH_DESC;
 import static connexion.logic.commands.CommandTestUtil.VALID_NOTE_AMY;
 import static connexion.logic.commands.CommandTestUtil.VALID_NOTE_BOB;

--- a/src/test/java/connexion/logic/parser/ParserUtilTest.java
+++ b/src/test/java/connexion/logic/parser/ParserUtilTest.java
@@ -61,36 +61,54 @@ public class ParserUtilTest {
     private static final String VALID_SCHEDULE = "2023-12-27-12-45";
     private static final String VALID_SCHEDULE_NAME = "Seminar";
 
+    /**
+     * Constructs an exception message given the type, the (invalid) value, & the final feedback message to give user
+     * This is, as of time of writing, exactly the same as the one in ParserUtil.
+     * This version is for testing, and thus exposed publicly.
+     * @return A string of format "Invalid {fieldType} given: {invalidValue}\n {feedbackMessage}
+     */
+    public static String makeExceptionMessage(String fieldType, String invalidValue, String feedbackMessage) {
+        return String.format("Invalid %s given: %s\n%s", fieldType, invalidValue, feedbackMessage);
+    }
     @Test
     public void parseIndex_invalidInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
-                -> ParserUtil.parseIndex("10 a"));
+        // PE : non-number value
+        assertThrows(ParseException.class,
+                makeExceptionMessage("index", "10 a", MESSAGE_INVALID_INDEX),
+                () -> ParserUtil.parseIndex("10 a"));
     }
 
     @Test
     public void parseIndex_outOfRangeInput_throwsParseException() {
+        // PE : overflowing value
+        String tooBig = Long.toString((long) Integer.MAX_VALUE + 1);
         assertThrows(ParseException.class,
-                "Invalid index given: " + (Integer.MAX_VALUE + 1) + "\n" + MESSAGE_INVALID_INDEX, ()
-                -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
-        assertThrows(ParseException.class, MESSAGE_INDEX_EXCEEDS_INT_LIMIT, ()
-            -> ParserUtil.parseIndex(Long.toString((long) Integer.MAX_VALUE + 1)));
+                makeExceptionMessage("index", tooBig, MESSAGE_INDEX_EXCEEDS_INT_LIMIT),
+                () -> ParserUtil.parseIndex(tooBig));
     }
     @Test
     public void parseIndex_negativeInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
-                -> ParserUtil.parseIndex("-1"));
+        //PE : negative input
+        assertThrows(ParseException.class,
+                makeExceptionMessage("index", "-1", MESSAGE_INVALID_INDEX),
+                () -> ParserUtil.parseIndex("-1"));
     }
     @Test
     public void parseIndex_fractionalInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
-                -> ParserUtil.parseIndex("1.1"));
+        //PE : fractional input
+        assertThrows(ParseException.class,
+                makeExceptionMessage("index", "1.1", MESSAGE_INVALID_INDEX),
+                () -> ParserUtil.parseIndex("1.1"));
     }
     @Test
     public void parseIndex_zeroInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
-                -> ParserUtil.parseIndex("0")); //just the one zero
-        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
-                -> ParserUtil.parseIndex("00")); //more zeros
+        //PE : 0s
+        assertThrows(ParseException.class,
+                makeExceptionMessage("index", "0", MESSAGE_INVALID_INDEX),
+                () -> ParserUtil.parseIndex("0")); //just the one zero
+        assertThrows(ParseException.class,
+                makeExceptionMessage("index", "00", MESSAGE_INVALID_INDEX),
+                () -> ParserUtil.parseIndex("00")); //more zeros
     }
 
 
@@ -115,7 +133,9 @@ public class ParserUtilTest {
 
     @Test
     public void parseName_invalidValue_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseName(INVALID_NAME));
+        assertThrows(ParseException.class,
+                makeExceptionMessage("name", INVALID_NAME, Name.MESSAGE_CONSTRAINTS),
+                () -> ParserUtil.parseName(INVALID_NAME));
     }
 
     @Test
@@ -138,7 +158,9 @@ public class ParserUtilTest {
 
     @Test
     public void parsePhone_invalidValue_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parsePhone(INVALID_PHONE));
+        assertThrows(ParseException.class,
+                makeExceptionMessage("phone number", INVALID_PHONE, Phone.MESSAGE_CONSTRAINTS),
+                () -> ParserUtil.parsePhone(INVALID_PHONE));
     }
 
     @Test
@@ -161,7 +183,10 @@ public class ParserUtilTest {
 
     @Test
     public void parseCompany_invalidValue_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseCompany(INVALID_COMPANY));
+        assertThrows(ParseException.class,
+                makeExceptionMessage("company name", INVALID_COMPANY.trim(), Company.MESSAGE_CONSTRAINTS),
+                () -> ParserUtil.parseCompany(INVALID_COMPANY));
+        // need to trim as user is to see trimmed version of input
     }
 
     @Test
@@ -184,7 +209,10 @@ public class ParserUtilTest {
 
     @Test
     public void parseJob_invalidValue_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseJob(INVALID_JOB));
+        assertThrows(ParseException.class,
+                makeExceptionMessage("job", INVALID_JOB.trim(), Job.MESSAGE_CONSTRAINTS),
+                () -> ParserUtil.parseJob(INVALID_JOB));
+        // need to trim as user is to see trimmed version of input
     }
 
     @Test
@@ -207,7 +235,9 @@ public class ParserUtilTest {
 
     @Test
     public void parseEmail_invalidValue_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseEmail(INVALID_EMAIL));
+        assertThrows(ParseException.class,
+                makeExceptionMessage("email", INVALID_EMAIL, Email.MESSAGE_CONSTRAINTS),
+                () -> ParserUtil.parseEmail(INVALID_EMAIL));
     }
 
     @Test
@@ -230,7 +260,9 @@ public class ParserUtilTest {
 
     @Test
     public void parseTag_invalidValue_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseTag(INVALID_TAG));
+        assertThrows(ParseException.class,
+                makeExceptionMessage("tag", INVALID_TAG, Tag.MESSAGE_CONSTRAINTS),
+                () -> ParserUtil.parseTag(INVALID_TAG));
     }
 
     @Test
@@ -276,12 +308,16 @@ public class ParserUtilTest {
 
     @Test
     public void parseNote_invalidValue_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseNote(INVALID_NOTE));
+        assertThrows(ParseException.class,
+                makeExceptionMessage("note", INVALID_NOTE, Note.MESSAGE_CONSTRAINTS),
+                () -> ParserUtil.parseNote(INVALID_NOTE));
     }
 
     @Test
     public void parseNote_invalidLength_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseNote(NOTE_WITH_INVALID_LENGTH));
+        assertThrows(ParseException.class,
+                Note.MESSAGE_CONSTRAINTS_CHARACTER_LIMIT,
+                () -> ParserUtil.parseNote(NOTE_WITH_INVALID_LENGTH));
     }
 
     @Test
@@ -304,7 +340,9 @@ public class ParserUtilTest {
 
     @Test
     public void parseSchedule_invalidValue_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseSchedule(INVALID_SCHEDULE));
+        assertThrows(ParseException.class,
+                makeExceptionMessage("schedule", INVALID_SCHEDULE, Schedule.MESSAGE_CONSTRAINTS),
+                () -> ParserUtil.parseSchedule(INVALID_SCHEDULE));
     }
 
     @Test
@@ -320,7 +358,9 @@ public class ParserUtilTest {
 
     @Test
     public void parseScheduleName_invalidValue_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseScheduleName(INVALID_SCHEDULE_NAME));
+        assertThrows(ParseException.class,
+                makeExceptionMessage("schedule name", INVALID_SCHEDULE_NAME, ScheduleName.MESSAGE_CONSTRAINTS),
+                () -> ParserUtil.parseScheduleName(INVALID_SCHEDULE_NAME));
     }
 
     @Test

--- a/src/test/java/connexion/logic/parser/ParserUtilTest.java
+++ b/src/test/java/connexion/logic/parser/ParserUtilTest.java
@@ -66,7 +66,8 @@ public class ParserUtilTest {
 
     @Test
     public void parseIndex_outOfRangeInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
+        assertThrows(ParseException.class,
+                "Invalid index given: " + (Integer.MAX_VALUE + 1) + "\n" + MESSAGE_INVALID_INDEX, ()
             -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
     }
 

--- a/src/test/java/connexion/logic/parser/ParserUtilTest.java
+++ b/src/test/java/connexion/logic/parser/ParserUtilTest.java
@@ -68,7 +68,7 @@ public class ParserUtilTest {
     public void parseIndex_outOfRangeInput_throwsParseException() {
         assertThrows(ParseException.class,
                 "Invalid index given: " + (Integer.MAX_VALUE + 1) + "\n" + MESSAGE_INVALID_INDEX, ()
-            -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
+                -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
     }
 
     @Test

--- a/src/test/java/connexion/logic/parser/ParserUtilTest.java
+++ b/src/test/java/connexion/logic/parser/ParserUtilTest.java
@@ -74,8 +74,8 @@ public class ParserUtilTest {
     public void parseIndex_invalidInput_throwsParseException() {
         // PE : non-number value
         assertThrows(ParseException.class,
-                makeExceptionMessage("index", "10 a", MESSAGE_INVALID_INDEX),
-                () -> ParserUtil.parseIndex("10 a"));
+                makeExceptionMessage("index", "10 a", MESSAGE_INVALID_INDEX), ()
+                        -> ParserUtil.parseIndex("10 a"));
     }
 
     @Test
@@ -83,32 +83,32 @@ public class ParserUtilTest {
         // PE : overflowing value
         String tooBig = Long.toString((long) Integer.MAX_VALUE + 1);
         assertThrows(ParseException.class,
-                makeExceptionMessage("index", tooBig, MESSAGE_INDEX_EXCEEDS_INT_LIMIT),
-                () -> ParserUtil.parseIndex(tooBig));
+                makeExceptionMessage("index", tooBig, MESSAGE_INDEX_EXCEEDS_INT_LIMIT), ()
+                        -> ParserUtil.parseIndex(tooBig));
     }
     @Test
     public void parseIndex_negativeInput_throwsParseException() {
         //PE : negative input
         assertThrows(ParseException.class,
-                makeExceptionMessage("index", "-1", MESSAGE_INVALID_INDEX),
-                () -> ParserUtil.parseIndex("-1"));
+                makeExceptionMessage("index", "-1", MESSAGE_INVALID_INDEX), ()
+                        -> ParserUtil.parseIndex("-1"));
     }
     @Test
     public void parseIndex_fractionalInput_throwsParseException() {
         //PE : fractional input
         assertThrows(ParseException.class,
-                makeExceptionMessage("index", "1.1", MESSAGE_INVALID_INDEX),
-                () -> ParserUtil.parseIndex("1.1"));
+                makeExceptionMessage("index", "1.1", MESSAGE_INVALID_INDEX), ()
+                        -> ParserUtil.parseIndex("1.1"));
     }
     @Test
     public void parseIndex_zeroInput_throwsParseException() {
         //PE : 0s
         assertThrows(ParseException.class,
-                makeExceptionMessage("index", "0", MESSAGE_INVALID_INDEX),
-                () -> ParserUtil.parseIndex("0")); //just the one zero
+                makeExceptionMessage("index", "0", MESSAGE_INVALID_INDEX), ()
+                        -> ParserUtil.parseIndex("0")); //just the one zero
         assertThrows(ParseException.class,
-                makeExceptionMessage("index", "00", MESSAGE_INVALID_INDEX),
-                () -> ParserUtil.parseIndex("00")); //more zeros
+                makeExceptionMessage("index", "00", MESSAGE_INVALID_INDEX), ()
+                        -> ParserUtil.parseIndex("00")); //more zeros
     }
 
 
@@ -134,8 +134,8 @@ public class ParserUtilTest {
     @Test
     public void parseName_invalidValue_throwsParseException() {
         assertThrows(ParseException.class,
-                makeExceptionMessage("name", INVALID_NAME, Name.MESSAGE_CONSTRAINTS),
-                () -> ParserUtil.parseName(INVALID_NAME));
+                makeExceptionMessage("name", INVALID_NAME, Name.MESSAGE_CONSTRAINTS), ()
+                        -> ParserUtil.parseName(INVALID_NAME));
     }
 
     @Test
@@ -159,8 +159,8 @@ public class ParserUtilTest {
     @Test
     public void parsePhone_invalidValue_throwsParseException() {
         assertThrows(ParseException.class,
-                makeExceptionMessage("phone number", INVALID_PHONE, Phone.MESSAGE_CONSTRAINTS),
-                () -> ParserUtil.parsePhone(INVALID_PHONE));
+                makeExceptionMessage("phone number", INVALID_PHONE, Phone.MESSAGE_CONSTRAINTS), ()
+                        -> ParserUtil.parsePhone(INVALID_PHONE));
     }
 
     @Test
@@ -184,8 +184,8 @@ public class ParserUtilTest {
     @Test
     public void parseCompany_invalidValue_throwsParseException() {
         assertThrows(ParseException.class,
-                makeExceptionMessage("company name", INVALID_COMPANY.trim(), Company.MESSAGE_CONSTRAINTS),
-                () -> ParserUtil.parseCompany(INVALID_COMPANY));
+                makeExceptionMessage("company name", INVALID_COMPANY.trim(), Company.MESSAGE_CONSTRAINTS), ()
+                        -> ParserUtil.parseCompany(INVALID_COMPANY));
         // need to trim as user is to see trimmed version of input
     }
 
@@ -210,8 +210,8 @@ public class ParserUtilTest {
     @Test
     public void parseJob_invalidValue_throwsParseException() {
         assertThrows(ParseException.class,
-                makeExceptionMessage("job", INVALID_JOB.trim(), Job.MESSAGE_CONSTRAINTS),
-                () -> ParserUtil.parseJob(INVALID_JOB));
+                makeExceptionMessage("job", INVALID_JOB.trim(), Job.MESSAGE_CONSTRAINTS), ()
+                        -> ParserUtil.parseJob(INVALID_JOB));
         // need to trim as user is to see trimmed version of input
     }
 
@@ -236,8 +236,8 @@ public class ParserUtilTest {
     @Test
     public void parseEmail_invalidValue_throwsParseException() {
         assertThrows(ParseException.class,
-                makeExceptionMessage("email", INVALID_EMAIL, Email.MESSAGE_CONSTRAINTS),
-                () -> ParserUtil.parseEmail(INVALID_EMAIL));
+                makeExceptionMessage("email", INVALID_EMAIL, Email.MESSAGE_CONSTRAINTS), ()
+                        -> ParserUtil.parseEmail(INVALID_EMAIL));
     }
 
     @Test
@@ -261,8 +261,8 @@ public class ParserUtilTest {
     @Test
     public void parseTag_invalidValue_throwsParseException() {
         assertThrows(ParseException.class,
-                makeExceptionMessage("tag", INVALID_TAG, Tag.MESSAGE_CONSTRAINTS),
-                () -> ParserUtil.parseTag(INVALID_TAG));
+                makeExceptionMessage("tag", INVALID_TAG, Tag.MESSAGE_CONSTRAINTS), ()
+                        -> ParserUtil.parseTag(INVALID_TAG));
     }
 
     @Test
@@ -309,15 +309,15 @@ public class ParserUtilTest {
     @Test
     public void parseNote_invalidValue_throwsParseException() {
         assertThrows(ParseException.class,
-                makeExceptionMessage("note", INVALID_NOTE, Note.MESSAGE_CONSTRAINTS),
-                () -> ParserUtil.parseNote(INVALID_NOTE));
+                makeExceptionMessage("note", INVALID_NOTE, Note.MESSAGE_CONSTRAINTS), ()
+                        -> ParserUtil.parseNote(INVALID_NOTE));
     }
 
     @Test
     public void parseNote_invalidLength_throwsParseException() {
         assertThrows(ParseException.class,
-                Note.MESSAGE_CONSTRAINTS_CHARACTER_LIMIT,
-                () -> ParserUtil.parseNote(NOTE_WITH_INVALID_LENGTH));
+                Note.MESSAGE_CONSTRAINTS_CHARACTER_LIMIT, ()
+                        -> ParserUtil.parseNote(NOTE_WITH_INVALID_LENGTH));
     }
 
     @Test
@@ -341,8 +341,8 @@ public class ParserUtilTest {
     @Test
     public void parseSchedule_invalidValue_throwsParseException() {
         assertThrows(ParseException.class,
-                makeExceptionMessage("schedule", INVALID_SCHEDULE, Schedule.MESSAGE_CONSTRAINTS),
-                () -> ParserUtil.parseSchedule(INVALID_SCHEDULE));
+                makeExceptionMessage("schedule", INVALID_SCHEDULE, Schedule.MESSAGE_CONSTRAINTS), ()
+                        -> ParserUtil.parseSchedule(INVALID_SCHEDULE));
     }
 
     @Test
@@ -359,8 +359,8 @@ public class ParserUtilTest {
     @Test
     public void parseScheduleName_invalidValue_throwsParseException() {
         assertThrows(ParseException.class,
-                makeExceptionMessage("schedule name", INVALID_SCHEDULE_NAME, ScheduleName.MESSAGE_CONSTRAINTS),
-                () -> ParserUtil.parseScheduleName(INVALID_SCHEDULE_NAME));
+                makeExceptionMessage("schedule name", INVALID_SCHEDULE_NAME, ScheduleName.MESSAGE_CONSTRAINTS), ()
+                        -> ParserUtil.parseScheduleName(INVALID_SCHEDULE_NAME));
     }
 
     @Test

--- a/src/test/java/connexion/logic/parser/ScheduleCommandParserTest.java
+++ b/src/test/java/connexion/logic/parser/ScheduleCommandParserTest.java
@@ -1,6 +1,7 @@
 package connexion.logic.parser;
 
 import static connexion.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static connexion.logic.Messages.MESSAGE_INVALID_FIELD_FORMAT;
 import static connexion.logic.commands.CommandTestUtil.AUTO_GIVEN_SCHEDULE_NAME;
 import static connexion.logic.commands.CommandTestUtil.INVALID_SCHEDULE;
 import static connexion.logic.commands.CommandTestUtil.INVALID_SCHEDULE_DATE;
@@ -25,6 +26,7 @@ import static connexion.testutil.ClockUtil.DEFAULT_TEST_TIME;
 import static connexion.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static connexion.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 
+import connexion.logic.commands.NoteCommand;
 import org.junit.jupiter.api.Test;
 
 import connexion.commons.core.index.Index;
@@ -46,28 +48,52 @@ public class ScheduleCommandParserTest {
     @Test
     public void parse_missingParts_failure() {
         // no index specified
-        assertParseFailure(parser, VALID_SCHEDULE_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, VALID_SCHEDULE_AMY,
+                String.format(MESSAGE_INVALID_FIELD_FORMAT,
+                        ParserUtilTest.makeExceptionMessage("index",
+                                VALID_SCHEDULE_AMY , ParserUtil.MESSAGE_INVALID_INDEX),
+                        ScheduleCommand.MESSAGE_USAGE));
 
         // no field specified
         assertParseFailure(parser, "1", MESSAGE_INVALID_FORMAT);
 
         // no index and no field specified
-        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "",
+                String.format(MESSAGE_INVALID_FIELD_FORMAT,
+                        ParserUtilTest.makeExceptionMessage("index",
+                                "" , ParserUtil.MESSAGE_INVALID_INDEX),
+                        ScheduleCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_invalidPreamble_failure() {
         // negative index
-        assertParseFailure(parser, "-5" + SCHEDULE_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "-5",
+                String.format(MESSAGE_INVALID_FIELD_FORMAT,
+                        ParserUtilTest.makeExceptionMessage("index",
+                                "-5" , ParserUtil.MESSAGE_INVALID_INDEX),
+                        ScheduleCommand.MESSAGE_USAGE));
 
         // zero index
-        assertParseFailure(parser, "0" + SCHEDULE_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "0",
+                String.format(MESSAGE_INVALID_FIELD_FORMAT,
+                        ParserUtilTest.makeExceptionMessage("index",
+                                "0" , ParserUtil.MESSAGE_INVALID_INDEX),
+                        ScheduleCommand.MESSAGE_USAGE));
 
         // invalid arguments being parsed as preamble
-        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1 some random string",
+                String.format(MESSAGE_INVALID_FIELD_FORMAT,
+                        ParserUtilTest.makeExceptionMessage("index",
+                                "1 some random string" , ParserUtil.MESSAGE_INVALID_INDEX),
+                        ScheduleCommand.MESSAGE_USAGE));
 
         // invalid prefix being parsed as preamble
-        assertParseFailure(parser, "1 e/ string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1 e/ string",
+                String.format(MESSAGE_INVALID_FIELD_FORMAT,
+                        ParserUtilTest.makeExceptionMessage("index",
+                                "1 e/ string" , ParserUtil.MESSAGE_INVALID_INDEX),
+                        ScheduleCommand.MESSAGE_USAGE));
     }
 
     @Test

--- a/src/test/java/connexion/logic/parser/ScheduleCommandParserTest.java
+++ b/src/test/java/connexion/logic/parser/ScheduleCommandParserTest.java
@@ -76,8 +76,8 @@ public class ScheduleCommandParserTest {
                 "Invalid schedule given: " + INVALID_SCHEDULE + "\n" + Schedule.MESSAGE_CONSTRAINTS);
         // invalid schedule
         assertParseFailure(parser, "1" + SCHEDULE_DESC_AMY + INVALID_SCHEDULE_NAME_DESC,
-                "Invalid schedule name given: " + INVALID_SCHEDULE_NAME + "\n" +
-                        ScheduleName.MESSAGE_CONSTRAINTS); // invalid schedule name
+                "Invalid schedule name given: " + INVALID_SCHEDULE_NAME + "\n"
+                        + ScheduleName.MESSAGE_CONSTRAINTS); // invalid schedule name
 
         // valid schedule name but invalid schedule
         assertParseFailure(parser, "1" + INVALID_SCHEDULE_DESC + SCHEDULE_NAME_DESC_AMY,

--- a/src/test/java/connexion/logic/parser/ScheduleCommandParserTest.java
+++ b/src/test/java/connexion/logic/parser/ScheduleCommandParserTest.java
@@ -26,7 +26,6 @@ import static connexion.testutil.ClockUtil.DEFAULT_TEST_TIME;
 import static connexion.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static connexion.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 
-import connexion.logic.commands.NoteCommand;
 import org.junit.jupiter.api.Test;
 
 import connexion.commons.core.index.Index;

--- a/src/test/java/connexion/logic/parser/ScheduleCommandParserTest.java
+++ b/src/test/java/connexion/logic/parser/ScheduleCommandParserTest.java
@@ -2,8 +2,11 @@ package connexion.logic.parser;
 
 import static connexion.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static connexion.logic.commands.CommandTestUtil.AUTO_GIVEN_SCHEDULE_NAME;
+import static connexion.logic.commands.CommandTestUtil.INVALID_SCHEDULE;
 import static connexion.logic.commands.CommandTestUtil.INVALID_SCHEDULE_DATE;
+import static connexion.logic.commands.CommandTestUtil.INVALID_SCHEDULE_DATE_DESC;
 import static connexion.logic.commands.CommandTestUtil.INVALID_SCHEDULE_DESC;
+import static connexion.logic.commands.CommandTestUtil.INVALID_SCHEDULE_NAME;
 import static connexion.logic.commands.CommandTestUtil.INVALID_SCHEDULE_NAME_DESC;
 import static connexion.logic.commands.CommandTestUtil.SCHEDULE_DESC_AMY;
 import static connexion.logic.commands.CommandTestUtil.SCHEDULE_DESC_BOB;
@@ -69,15 +72,19 @@ public class ScheduleCommandParserTest {
 
     @Test
     public void parse_invalidValue_failure() {
-        assertParseFailure(parser, "1" + INVALID_SCHEDULE_DESC, Schedule.MESSAGE_CONSTRAINTS); // invalid schedule
+        assertParseFailure(parser, "1" + INVALID_SCHEDULE_DESC,
+                "Invalid schedule given: " + INVALID_SCHEDULE + "\n" + Schedule.MESSAGE_CONSTRAINTS);
+        // invalid schedule
         assertParseFailure(parser, "1" + SCHEDULE_DESC_AMY + INVALID_SCHEDULE_NAME_DESC,
-                ScheduleName.MESSAGE_CONSTRAINTS); // invalid schedule name
+                "Invalid schedule name given: " + INVALID_SCHEDULE_NAME + "\n" +
+                        ScheduleName.MESSAGE_CONSTRAINTS); // invalid schedule name
 
         // valid schedule name but invalid schedule
         assertParseFailure(parser, "1" + INVALID_SCHEDULE_DESC + SCHEDULE_NAME_DESC_AMY,
-                Schedule.MESSAGE_CONSTRAINTS); // invalid schedule
-        assertParseFailure(parser, "1" + INVALID_SCHEDULE_DATE + SCHEDULE_NAME_DESC_AMY,
-                Schedule.MESSAGE_CONSTRAINTS);
+                "Invalid schedule given: " + INVALID_SCHEDULE + "\n" + Schedule.MESSAGE_CONSTRAINTS);
+        // invalid schedule
+        assertParseFailure(parser, "1" + INVALID_SCHEDULE_DATE_DESC + SCHEDULE_NAME_DESC_AMY,
+                "Invalid schedule given: " + INVALID_SCHEDULE_DATE + "\n" + Schedule.MESSAGE_CONSTRAINTS);
     }
 
     @Test

--- a/src/test/java/connexion/logic/parser/UnMarkCommandParserTest.java
+++ b/src/test/java/connexion/logic/parser/UnMarkCommandParserTest.java
@@ -1,10 +1,12 @@
 package connexion.logic.parser;
 
 import static connexion.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static connexion.logic.Messages.MESSAGE_INVALID_FIELD_FORMAT;
 import static connexion.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static connexion.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static connexion.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
+import connexion.logic.commands.MarkCommand;
 import org.junit.jupiter.api.Test;
 
 import connexion.logic.commands.UnMarkCommand;
@@ -13,7 +15,12 @@ public class UnMarkCommandParserTest {
     private UnMarkCommandParser parser = new UnMarkCommandParser();
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnMarkCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "      " ,
+                String.format(MESSAGE_INVALID_FIELD_FORMAT,
+                        ParserUtilTest.makeExceptionMessage("index",
+                                "      ".trim() , ParserUtil.MESSAGE_INVALID_INDEX),
+                        UnMarkCommand.MESSAGE_USAGE));
+
     }
 
     @Test
@@ -23,6 +30,10 @@ public class UnMarkCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnMarkCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a",
+                String.format(MESSAGE_INVALID_FIELD_FORMAT,
+                        ParserUtilTest.makeExceptionMessage("index",
+                                "a" , ParserUtil.MESSAGE_INVALID_INDEX),
+                        UnMarkCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/connexion/logic/parser/UnMarkCommandParserTest.java
+++ b/src/test/java/connexion/logic/parser/UnMarkCommandParserTest.java
@@ -1,12 +1,10 @@
 package connexion.logic.parser;
 
-import static connexion.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static connexion.logic.Messages.MESSAGE_INVALID_FIELD_FORMAT;
 import static connexion.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static connexion.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static connexion.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
-import connexion.logic.commands.MarkCommand;
 import org.junit.jupiter.api.Test;
 
 import connexion.logic.commands.UnMarkCommand;


### PR DESCRIPTION
closes #186

Current behaviour is to parse extra params as part of field

Updates UG also about this behaviour.

Notable exception is that of note size length, as that is likely to cause bugs & user error is quite obvious from message.

This is arguably a bug as , for example, below, the user DID enter the correct schedule time, but added an extra field. Hence, was rejected (rightly) while telling the user that it's because the schedule time is wrong(wrong, it was right!).

![image](https://github.com/AY2324S1-CS2103-F13-1/tp/assets/54708640/b034c42f-5bac-45b6-a719-885b995ed93f)


Edits to the following & implements for all fields including index

![image](https://github.com/AY2324S1-CS2103-F13-1/tp/assets/54708640/27087f35-ebb4-4e07-bf0d-ff00e43e71e7)
