### PR TITLE
Clarifies how prefixes are defined

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -56,7 +56,8 @@ title: User Guide
 
 * Parameters can be in any order.<br>
   e.g. if the command specifies `n/NAME p/PHONE_NUMBER`, `p/PHONE_NUMBER n/NAME` is also acceptable.
-
+* As seen above, the app uses prefixes to indicate the type of parameter, like `n/` for `NAME`.
+* Prefixes are defined by having a space before the prefix proper. E.g. `n/ Johnp/123456789` will be interpreted as supplying `Johnp/123456789` to the `NAME` parameter.
 * Extraneous parameters for commands that do not take in parameters (such as `help`, `list`, `exit` and `clear`) will be ignored.<br>
   e.g. if the command specifies `help 123`, it will be interpreted as `help`.
 * Commands that modify contacts' detail or create contacts, i.e. `add` and `edit`, time-stamp the contact with a last modified field.


### PR DESCRIPTION
Closes #193  and partially addresses #215

Clarifies that prefixes are defined by having a space in front, e.g. `n/ Johnp/123456789` means that you're giving `Johnp/123456789` to the NAME parameter.

Closes the issue as then it's not a bug just a product of how we parse which is explicitly stated behaviour.
