### PR TITLE
Fix email parsing

### DIFF
--- a/src/main/java/connexion/model/person/Email.java
+++ b/src/main/java/connexion/model/person/Email.java
@@ -10,7 +10,7 @@ import static java.util.Objects.requireNonNull;
 public class Email implements PersonDetailField<String> {
 
     private static final String SPECIAL_CHARACTERS = "+_.-"; // one or more special characters as defined
-    private static final String SPECIAL_CHAR_REGEX = String.format("[%s]+",SPECIAL_CHARACTERS);
+    private static final String SPECIAL_CHAR_REGEX = String.format("[%s]+", SPECIAL_CHARACTERS);
     public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
             + "and adhere to the following constraints:\n"
             + "1. The local-part should only contain alphanumeric characters and these special characters, excluding "

--- a/src/main/java/connexion/model/person/Email.java
+++ b/src/main/java/connexion/model/person/Email.java
@@ -9,7 +9,10 @@ import static java.util.Objects.requireNonNull;
  */
 public class Email implements PersonDetailField<String> {
 
-    private static final String SPECIAL_CHARACTERS = "[+_.-]+"; // one or more special characters as defined
+
+
+    private static final String SPECIAL_CHARACTERS = "+_.-"; // one or more special characters as defined
+    private static final String SPECIAL_CHAR_REGEX = String.format("[%s]+",SPECIAL_CHARACTERS);
     public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
             + "and adhere to the following constraints:\n"
             + "1. The local-part should only contain alphanumeric characters and these special characters, excluding "
@@ -25,7 +28,7 @@ public class Email implements PersonDetailField<String> {
     private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]+"; // alphanumeric characters except underscore
     private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "("
             //start with alphanumeric, all remaining is optional.
-            + "(" + SPECIAL_CHARACTERS + "|" + ALPHANUMERIC_NO_UNDERSCORE + ")*"
+            + "(" + SPECIAL_CHAR_REGEX + "|" + ALPHANUMERIC_NO_UNDERSCORE + ")*"
             //middle can be any number of special chars or alphanumeric, repeated zero or more times
             + ALPHANUMERIC_NO_UNDERSCORE + ")?"; //end with alphanumeric (still optional)
 

--- a/src/main/java/connexion/model/person/Email.java
+++ b/src/main/java/connexion/model/person/Email.java
@@ -9,7 +9,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class Email implements PersonDetailField<String> {
 
-    private static final String SPECIAL_CHARACTERS = "+_.-";
+    private static final String SPECIAL_CHARACTERS = "[+_.-]+"; // one or more special characters as defined
     public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
             + "and adhere to the following constraints:\n"
             + "1. The local-part should only contain alphanumeric characters and these special characters, excluding "
@@ -23,8 +23,14 @@ public class Email implements PersonDetailField<String> {
             + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.";
     // alphanumeric and special characters
     private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]+"; // alphanumeric characters except underscore
-    private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "([" + SPECIAL_CHARACTERS + "]"
-            + ALPHANUMERIC_NO_UNDERSCORE + ")*";
+    private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "("
+            //start with alphanumeric, all remaining is optional.
+            + "(" +  SPECIAL_CHARACTERS  + "|" + ALPHANUMERIC_NO_UNDERSCORE +")*"
+            //middle can be any number of special chars or alphanumeric, repeated zero or more times
+            + ALPHANUMERIC_NO_UNDERSCORE + ")?";
+            //end with alphanumeric (still optional)
+
+    //^ALPHANUM((SPECIAL|ALPHANUM)*)ALPHANUM)*
     private static final String DOMAIN_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE
             + "(-" + ALPHANUMERIC_NO_UNDERSCORE + ")*";
     private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars

--- a/src/main/java/connexion/model/person/Email.java
+++ b/src/main/java/connexion/model/person/Email.java
@@ -38,6 +38,8 @@ public class Email implements PersonDetailField<String> {
             + "(-?" + ALPHANUMERIC_NO_UNDERSCORE + ")+";
     // You must have one or more alphanumerics after the first,
     // and you may split them up with hyphens as you wish.
+    // This guarantees our at-least-two characters condition.
+
     private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
     public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
 

--- a/src/main/java/connexion/model/person/Email.java
+++ b/src/main/java/connexion/model/person/Email.java
@@ -25,12 +25,10 @@ public class Email implements PersonDetailField<String> {
     private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]+"; // alphanumeric characters except underscore
     private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "("
             //start with alphanumeric, all remaining is optional.
-            + "(" +  SPECIAL_CHARACTERS  + "|" + ALPHANUMERIC_NO_UNDERSCORE +")*"
+            + "(" + SPECIAL_CHARACTERS + "|" + ALPHANUMERIC_NO_UNDERSCORE + ")*"
             //middle can be any number of special chars or alphanumeric, repeated zero or more times
-            + ALPHANUMERIC_NO_UNDERSCORE + ")?";
-            //end with alphanumeric (still optional)
+            + ALPHANUMERIC_NO_UNDERSCORE + ")?"; //end with alphanumeric (still optional)
 
-    //^ALPHANUM((SPECIAL|ALPHANUM)*)ALPHANUM)*
     private static final String DOMAIN_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE
             + "(-" + ALPHANUMERIC_NO_UNDERSCORE + ")*";
     private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars

--- a/src/main/java/connexion/model/person/Email.java
+++ b/src/main/java/connexion/model/person/Email.java
@@ -29,9 +29,15 @@ public class Email implements PersonDetailField<String> {
             //middle can be any number of special chars or alphanumeric, repeated zero or more times
             + ALPHANUMERIC_NO_UNDERSCORE + ")?"; //end with alphanumeric (still optional)
 
+
+
     private static final String DOMAIN_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE
-            + "(-" + ALPHANUMERIC_NO_UNDERSCORE + ")*";
-    private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars
+            + "(-?" + ALPHANUMERIC_NO_UNDERSCORE + ")*";
+    // you may have any number (including 0) of hyphens, but at least one alphanumeric needs to follow
+    private static final String DOMAIN_LAST_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE
+            + "(-?" + ALPHANUMERIC_NO_UNDERSCORE + ")+";
+    // You must have one or more alphanumerics after the first,
+    // and you may split them up with hyphens as you wish.
     private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
     public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
 

--- a/src/main/java/connexion/model/person/Email.java
+++ b/src/main/java/connexion/model/person/Email.java
@@ -9,8 +9,6 @@ import static java.util.Objects.requireNonNull;
  */
 public class Email implements PersonDetailField<String> {
 
-
-
     private static final String SPECIAL_CHARACTERS = "+_.-"; // one or more special characters as defined
     private static final String SPECIAL_CHAR_REGEX = String.format("[%s]+",SPECIAL_CHARACTERS);
     public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "

--- a/src/test/java/connexion/model/person/EmailTest.java
+++ b/src/test/java/connexion/model/person/EmailTest.java
@@ -46,7 +46,7 @@ public class EmailTest {
         assertFalse(Email.isValidEmail("peter@jack@example.com")); // '@' symbol in local part
         assertFalse(Email.isValidEmail("-peterjack@example.com")); // local part starts with a hyphen
         assertFalse(Email.isValidEmail("peterjack-@example.com")); // local part ends with a hyphen
-        assertFalse(Email.isValidEmail("peter..jack@example.com")); // local part has two consecutive periods
+        assertFalse(Email.isValidEmail("-p-peterjack@example.com")); // starts with hyphen, with hyphen in the middle
         assertFalse(Email.isValidEmail("peterjack@example@com")); // '@' symbol in domain name
         assertFalse(Email.isValidEmail("peterjack@.example.com")); // domain name starts with a period
         assertFalse(Email.isValidEmail("peterjack@example.com.")); // domain name ends with a period
@@ -66,6 +66,10 @@ public class EmailTest {
         assertTrue(Email.isValidEmail("peter_jack@very-very-very-long-example.com")); // long domain name
         assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@example.com")); // long local part
         assertTrue(Email.isValidEmail("e1234567@u.nus.edu")); // more than one period in domain
+        assertTrue(Email.isValidEmail("peter..jack@example.com")); // local part has two consecutive periods is ok
+        assertTrue(Email.isValidEmail("peter..jack--michael@example.com")); // alphanumeric separating consecutive
+        assertTrue(Email.isValidEmail("peter+_.-jack@example.com")); // all special characters in a row
+
     }
 
     @Test

--- a/src/test/java/connexion/model/person/EmailTest.java
+++ b/src/test/java/connexion/model/person/EmailTest.java
@@ -51,6 +51,8 @@ public class EmailTest {
         assertFalse(Email.isValidEmail("peterjack@.example.com")); // domain name starts with a period
         assertFalse(Email.isValidEmail("peterjack@example.com.")); // domain name ends with a period
         assertFalse(Email.isValidEmail("peterjack@-example.com")); // domain name starts with a hyphen
+        assertFalse(Email.isValidEmail("peterjack@example-.com")); // domain label ends with a hyphen
+        assertFalse(Email.isValidEmail("peterjack@example.-com")); // domain end label starts with a hyphen
         assertFalse(Email.isValidEmail("peterjack@example.com-")); // domain name ends with a hyphen
         assertFalse(Email.isValidEmail("peterjack@example.c")); // top level domain has less than two chars
 
@@ -69,6 +71,7 @@ public class EmailTest {
         assertTrue(Email.isValidEmail("peter..jack@example.com")); // local part has two consecutive periods is ok
         assertTrue(Email.isValidEmail("peter..jack--michael@example.com")); // alphanumeric separating consecutive
         assertTrue(Email.isValidEmail("peter+_.-jack@example.com")); // all special characters in a row
+        assertTrue(Email.isValidEmail("peterjack@a-1.a-a")); // mix of hyphens across two dots with min size strings
         assertTrue(Email.isValidEmail("peterjack@aa-1.a-a")); // mix of hyphens across two dots with min size strings
 
     }

--- a/src/test/java/connexion/model/person/EmailTest.java
+++ b/src/test/java/connexion/model/person/EmailTest.java
@@ -69,6 +69,7 @@ public class EmailTest {
         assertTrue(Email.isValidEmail("peter..jack@example.com")); // local part has two consecutive periods is ok
         assertTrue(Email.isValidEmail("peter..jack--michael@example.com")); // alphanumeric separating consecutive
         assertTrue(Email.isValidEmail("peter+_.-jack@example.com")); // all special characters in a row
+        assertTrue(Email.isValidEmail("peterjack@aa-1.a-a")); // mix of hyphens across two dots with min size strings
 
     }
 

--- a/src/test/java/connexion/model/person/EmailTest.java
+++ b/src/test/java/connexion/model/person/EmailTest.java
@@ -71,8 +71,8 @@ public class EmailTest {
         assertTrue(Email.isValidEmail("peter..jack@example.com")); // local part has two consecutive periods is ok
         assertTrue(Email.isValidEmail("peter..jack--michael@example.com")); // alphanumeric separating consecutive
         assertTrue(Email.isValidEmail("peter+_.-jack@example.com")); // all special characters in a row
+        assertTrue(Email.isValidEmail("peterjack@a-a")); // shortest possible with hyphen
         assertTrue(Email.isValidEmail("peterjack@a-1.a-a")); // mix of hyphens across two dots with min size strings
-        assertTrue(Email.isValidEmail("peterjack@aa-1.a-a")); // mix of hyphens across two dots with min size strings
 
     }
 


### PR DESCRIPTION
Closes #202 
Closes #204 

### **Local part**
The regex is still mostly impenetrable without taking a moment to figure out what it actually means but should be a bit better

Regex in this PR for local part will become 
`^ALPHANUMERIC((SPECIAL_CHAR|ALPHANUMERIC)*ALPHANUMERIC)?`

Which roughly means that it must start with an alphanumeric (w/o underscore) character, then (optional) have zero or more of either (special char or alphanumeric) followed by one alphanumeric.

This should be right, though I invite anyone who's reviewing to double-check that this makes sense.

Test cases updated to reflect this new behaviour. There was a test case for this exact scenario that was supposed to fail, in contrast to advertised behaviour.

### **Domain part**
regex still similarly quite bad, but works properly now.
No real way to make it easy to read as far as I can see

Considered splitting up the suffix (`+` vs `*`) but that kind of ended up making it about as bad to read because the fact that you're modifying number of times you're repeating the last unit only obfuscated.

Also added comments roughly describing the logic of the regex portions.

Test cases also updated.
