### PR TITLE
Fix index parsing to give correct error for too-big-integer & edit test cases

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -62,6 +62,8 @@ title: User Guide
   e.g. if the command specifies `help 123`, it will be interpreted as `help`.
 * Commands that modify contacts' detail or create contacts, i.e. `add` and `edit`, time-stamp the contact with a last modified field.
   * `mark` is not considered as modifying contact's detail and hence does not change the last modified date.
+* Commands that accept indices as parameters can only accept positive integers less than 2147483647, and a valid index
+  i.e. the valid index must be between 1 and the lower of (list size, 2147483647) (inclusive)
 * If you are using a PDF version of this document, be careful when copying and pasting commands that span multiple lines as space characters surrounding line-breaks may be omitted when copied over to the application.
 </div>
 

--- a/src/main/java/connexion/logic/parser/ParserUtil.java
+++ b/src/main/java/connexion/logic/parser/ParserUtil.java
@@ -35,9 +35,14 @@ public class ParserUtil {
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
         String trimmedIndex = oneBasedIndex.trim();
-        if (!((trimmedIndex).matches("\\d+"))) { //if it's not just digits, clearly wrong
+        if (!((trimmedIndex).matches("\\d+"))) {
+            //if it's not just digits, clearly wrong
+            //notably, this catches -ve numbers (as the "-" causes it to fail the check)
             throw new ParseException((MESSAGE_INVALID_INDEX));
-        } else if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) { // else, it's likely an out-of-bounds error
+        } else if (trimmedIndex.equals("0")) { //if it's zero, also wrong.
+            throw new ParseException(MESSAGE_INVALID_INDEX);
+        } else if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
+            // else, it's likely an out-of-bounds error
             throw new ParseException(MESSAGE_INDEX_EXCEEDS_INT_LIMIT);
         }
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));

--- a/src/main/java/connexion/logic/parser/ParserUtil.java
+++ b/src/main/java/connexion/logic/parser/ParserUtil.java
@@ -25,6 +25,8 @@ import connexion.model.tag.Tag;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_INDEX_EXCEEDS_INT_LIMIT =
+            "Index exceeds the allowed integer limit in Java of 2147483647";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -33,8 +35,10 @@ public class ParserUtil {
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
         String trimmedIndex = oneBasedIndex.trim();
-        if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
-            throw new ParseException(MESSAGE_INVALID_INDEX);
+        if (!((trimmedIndex).matches("\\d+"))) { //if it's not just digits, clearly wrong
+            throw new ParseException((MESSAGE_INVALID_INDEX));
+        } else if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) { // else, it's likely an out-of-bounds error
+            throw new ParseException(MESSAGE_INDEX_EXCEEDS_INT_LIMIT);
         }
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));
     }

--- a/src/main/java/connexion/logic/parser/ParserUtil.java
+++ b/src/main/java/connexion/logic/parser/ParserUtil.java
@@ -39,7 +39,8 @@ public class ParserUtil {
             //if it's not just digits, clearly wrong
             //notably, this catches -ve numbers (as the "-" causes it to fail the check)
             throw new ParseException((MESSAGE_INVALID_INDEX));
-        } else if (trimmedIndex.equals("0")) { //if it's zero, also wrong.
+        } else if (trimmedIndex.matches("0+")) {
+            //if it's some amount of just zeros, also wrong
             throw new ParseException(MESSAGE_INVALID_INDEX);
         } else if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
             // else, it's likely an out-of-bounds error

--- a/src/test/java/connexion/logic/parser/ParserUtilTest.java
+++ b/src/test/java/connexion/logic/parser/ParserUtilTest.java
@@ -12,9 +12,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import connexion.commons.core.index.Index;
 import org.junit.jupiter.api.Test;
 
+import connexion.commons.core.index.Index;
 import connexion.logic.parser.exceptions.ParseException;
 import connexion.model.person.Company;
 import connexion.model.person.Email;

--- a/src/test/java/connexion/logic/parser/ParserUtilTest.java
+++ b/src/test/java/connexion/logic/parser/ParserUtilTest.java
@@ -1,5 +1,6 @@
 package connexion.logic.parser;
 
+import static connexion.logic.parser.ParserUtil.MESSAGE_INDEX_EXCEEDS_INT_LIMIT;
 import static connexion.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static connexion.testutil.Assert.assertThrows;
 import static connexion.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -61,14 +62,21 @@ public class ParserUtilTest {
 
     @Test
     public void parseIndex_invalidInput_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseIndex("10 a"));
+        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
+                -> ParserUtil.parseIndex("10 a"));
     }
 
     @Test
     public void parseIndex_outOfRangeInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
-            -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
+        assertThrows(ParseException.class, MESSAGE_INDEX_EXCEEDS_INT_LIMIT, ()
+            -> ParserUtil.parseIndex(Long.toString((long) Integer.MAX_VALUE + 1)));
     }
+    @Test
+    public void parseIndex_negativeInput_throwsParseException() {
+        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
+                -> ParserUtil.parseIndex("-1"));
+    }
+
 
     @Test
     public void parseIndex_validInput_success() throws Exception {

--- a/src/test/java/connexion/logic/parser/ParserUtilTest.java
+++ b/src/test/java/connexion/logic/parser/ParserUtilTest.java
@@ -76,6 +76,17 @@ public class ParserUtilTest {
         assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
                 -> ParserUtil.parseIndex("-1"));
     }
+    @Test
+    public void parseIndex_fractionalInput_throwsParseException() {
+        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
+                -> ParserUtil.parseIndex("1.1"));
+    }
+    @Test
+    public void parseIndex_zeroInput_throwsParseException() {
+        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
+                -> ParserUtil.parseIndex("0"));
+    }
+
 
 
     @Test

--- a/src/test/java/connexion/logic/parser/ParserUtilTest.java
+++ b/src/test/java/connexion/logic/parser/ParserUtilTest.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import connexion.commons.core.index.Index;
 import org.junit.jupiter.api.Test;
 
 import connexion.logic.parser.exceptions.ParseException;
@@ -84,7 +85,9 @@ public class ParserUtilTest {
     @Test
     public void parseIndex_zeroInput_throwsParseException() {
         assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
-                -> ParserUtil.parseIndex("0"));
+                -> ParserUtil.parseIndex("0")); //just the one zero
+        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
+                -> ParserUtil.parseIndex("00")); //more zeros
     }
 
 
@@ -96,6 +99,10 @@ public class ParserUtilTest {
 
         // Leading and trailing whitespaces
         assertEquals(INDEX_FIRST_PERSON, ParserUtil.parseIndex("  1  "));
+
+        // all possible digits
+        assertEquals(Index.fromOneBased(1234567890),
+                ParserUtil.parseIndex("1234567890"));
     }
 
     @Test


### PR DESCRIPTION
Closes #210 


Now, gives error to correctly reflect that the number is too big.

The if-else ladder should catch cases where it's negative and zero (as commented)

Throws the too-big message if and only if the number is larger than `Integer.MAX_VALUE`.